### PR TITLE
fix: remove unused variables to pass lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
       dev-dependencies:
         dependency-type: development
       aws-sdk:
-        patterns: ["@aws-sdk/*"]
+        patterns: ['@aws-sdk/*']
       react-router:
-        patterns: ["@react-router/*", "react-router"]
+        patterns: ['@react-router/*', 'react-router']
       cloudscape:
-        patterns: ["@cloudscape-design/*"]
+        patterns: ['@cloudscape-design/*']

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Capability Insights for AWS consists of a CloudFormation stack, Lambda function 
 
 Capability Insights for AWS deploys into your existing network infrastructure. You will need the following in the AWS account and region where you want the dashboard accessible:
 
-| Resource | Description |
-| -------- | ----------- |
-| VPC | The VPC where you want the dashboard deployed. Must have DNS resolution enabled. |
-| └ Subnet (with internet gateway) | Users access the dashboard from this subnet. |
-| └ Subnet (without internet gateway) | Lambda functions run here securely with no direct internet access. |
-| S3 access point ARN | How the solution reads capability data from the source. Provided during onboarding. |
+| Resource                            | Description                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| VPC                                 | The VPC where you want the dashboard deployed. Must have DNS resolution enabled.    |
+| └ Subnet (with internet gateway)    | Users access the dashboard from this subnet.                                        |
+| └ Subnet (without internet gateway) | Lambda functions run here securely with no direct internet access.                  |
+| S3 access point ARN                 | How the solution reads capability data from the source. Provided during onboarding. |
 
 If you don't have an existing VPC and subnets to deploy into, we provide a [Sample Environment Stack](#sample-environment-stack-optional) that creates these resources for you.
 
@@ -105,13 +105,13 @@ npm run deploy -- \
   --source-folders aws-cn,public
 ```
 
-| Flag                              | Description                                                                                      |
-| --------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `--private-vpc-id`                | VPC ID. Must have DNS resolution and DNS hostnames enabled.                                      |
-| `--backend-subnet-id`             | Subnet without an internet gateway, used for Lambda compute.                                     |
-| `--api-access-subnet-id`          | Subnet with an internet gateway, used for user access and the API Gateway VPC Endpoint.          |
-| `--deployment-assets-bucket-name` | S3 bucket where deployment assets (Lambda code zip) are stored.                                  |
-| `--source-access-point-arn`       | S3 access point ARN for the capability data source (provided during onboarding).                 |
+| Flag                              | Description                                                                                                             |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--private-vpc-id`                | VPC ID. Must have DNS resolution and DNS hostnames enabled.                                                             |
+| `--backend-subnet-id`             | Subnet without an internet gateway, used for Lambda compute.                                                            |
+| `--api-access-subnet-id`          | Subnet with an internet gateway, used for user access and the API Gateway VPC Endpoint.                                 |
+| `--deployment-assets-bucket-name` | S3 bucket where deployment assets (Lambda code zip) are stored.                                                         |
+| `--source-access-point-arn`       | S3 access point ARN for the capability data source (provided during onboarding).                                        |
 | `--source-folders`                | Comma-separated list of data sources to pull from (default: `public`). Include additional partitions if granted access. |
 
 #### Teardown

--- a/source/website/app/components/availability/availability-stat-card.tsx
+++ b/source/website/app/components/availability/availability-stat-card.tsx
@@ -1,9 +1,7 @@
 import Box from '@cloudscape-design/components/box';
 import Badge from '@cloudscape-design/components/badge';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import type {
-  RegionalAvailability,
-} from '@capability-insights/shared/types/availability/regional-availability';
+import type { RegionalAvailability } from '@capability-insights/shared/types/availability/regional-availability';
 
 interface AvailabilityStatCardProps {
   label: string;

--- a/source/website/app/components/availability/availability-table-properties.tsx
+++ b/source/website/app/components/availability/availability-table-properties.tsx
@@ -3,10 +3,7 @@ import type { PropertyFilterProps } from '@cloudscape-design/components/property
 import CollectionPreferences, {
   type CollectionPreferencesProps,
 } from '@cloudscape-design/components/collection-preferences';
-import type {
-  PropertyFilterQuery,
-  PropertyFilterToken,
-} from '@cloudscape-design/collection-hooks';
+import type { PropertyFilterQuery, PropertyFilterToken } from '@cloudscape-design/collection-hooks';
 import type { Region } from '@capability-insights/shared/types/capability/region';
 import type { RegionalAvailability } from '@capability-insights/shared/types/availability/regional-availability';
 import type { AvailabilityStatus } from '@capability-insights/shared/types/availability/availability-status';
@@ -60,9 +57,7 @@ export function createColumns({
   ];
 }
 
-export function createFilteringProperties(
-  regions: Region[],
-): PropertyFilterProps.FilteringProperty[] {
+export function createFilteringProperties(regions: Region[]): PropertyFilterProps.FilteringProperty[] {
   return [
     {
       key: 'name',
@@ -87,15 +82,6 @@ export function createFilteringProperties(
     })),
   ];
 }
-
-/**
- * Known property keys on RegionalAvailability that the filter can resolve
- * directly, without needing a generic record cast.
- */
-const KNOWN_KEYS: ReadonlySet<string> = new Set<keyof RegionalAvailability>([
-  'name',
-  'regionalAvailabilityType',
-]);
 
 /**
  * Creates a filtering function that handles regular properties, region

--- a/source/website/app/mappers/regional-availability.mapper.ts
+++ b/source/website/app/mappers/regional-availability.mapper.ts
@@ -1,7 +1,6 @@
 import { ProductType, type Product } from '@capability-insights/shared/types/capability/product';
 import type { ApiService } from '@capability-insights/shared/types/capability/api';
 import type { CfnResource } from '@capability-insights/shared/types/capability/cfn';
-import type { RegionCode } from '@capability-insights/shared/types/capability/region';
 import type {
   ProductAvailability,
   ApiAvailability,


### PR DESCRIPTION
## Summary (required)

Remove unused variables flagged by the linter to fix the Build workflow.

## Details (required)

- Removed unused `KNOWN_KEYS` constant from `availability-table-properties.tsx`
- Removed unused `RegionCode` import from `regional-availability.mapper.ts`

## Testing (required)

- [x] Local development server

**How did you test this?**

Ran `npm run lint` locally and confirmed no warnings.

## Versioning & Releases

No version bump needed.