### PR TITLE
fix: remove unnecessary kms:Decrypt from DataFetch Lambda IAM policy

### DIFF
--- a/source/constructs/lib/stacks/capability-insights-stack.ts
+++ b/source/constructs/lib/stacks/capability-insights-stack.ts
@@ -222,13 +222,6 @@ export class CapabilityInsightsStack extends cdk.Stack {
               },
               {
                 Effect: 'Allow',
-                Action: ['kms:Decrypt'],
-                Resource: cdk.Fn.sub('arn:${AWS::Partition}:kms:*:${SourceAccount}:key/*', {
-                  SourceAccount: cdk.Fn.select(4, cdk.Fn.split(':', sourceAccessPointArnParameter.valueAsString)),
-                }),
-              },
-              {
-                Effect: 'Allow',
                 Action: ['s3:PutObject'],
                 Resource: cdk.Fn.sub('${BucketArn}/data/*', {
                   BucketArn: cdk.Fn.getAtt(websiteBucket.logicalId, 'Arn').toString(),


### PR DESCRIPTION
## Summary

Remove the `kms:Decrypt` IAM policy statement from the DataFetch Lambda role. Testing confirmed the data sync works without it, reducing the IAM permissions surface.

## Details

 The `kms:Decrypt` statement has been removed to follow least-privilege.

The `s3:GetObject` with `Resource: *` and `s3:DataAccessPointAccount` condition remains unchanged — this is required for cross-account access point access.

## Testing

Check all that apply:

- [ ] Unit tests
- [ ] Local development server
- [x] Full deployment

**How did you test this?**

Full `npm run dev:deploy`

1. CloudFormation stack updated successfully (IAM policy change applied)
2. DataFetch Lambda invoked — all 8 files written with no errors
3. Website accessible and serving data through SOCKS proxy
4. No `AccessDenied` errors in Lambda CloudWatch logs

This was Test 4 in the security findings matrix (original S3 policy without KMS), which had not been previously tested.

## Screenshots

N/A — IAM policy change, no UI impact.

## ⚠️ Branch Target

> All PRs must target the **`development`** branch. PRs opened against `main` will be closed.

## Versioning & Releases

When changes are merged to `main`, the release workflow automatically builds and publishes a [GitHub Release](https://github.com/aws/capability-insights-for-aws/releases) with deployment artifacts (`build-assets.zip`).

- If the version in `package.json` hasn't changed, the existing release is overwritten with fresh artifacts.
- If the version is bumped, a new release is created and previous versions remain available.

Bump the `version` in `package.json` when you want to cut a new release:

- **Patch** (1.0.0 → 1.0.1): Bug fixes, dependency updates, docs changes
- **Minor** (1.0.0 → 1.1.0): New features, non-breaking changes
- **Major** (1.0.0 → 2.0.0): Breaking changes (e.g., new required CloudFormation parameters)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.