### PR TITLE
feat: add cdk snapshot tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7950,7 +7950,8 @@
         "@tsconfig/node-lts": "^20.1.3",
         "aws-cdk": "^2.1106.1",
         "aws-cdk-lib": "^2.245.0",
-        "constructs": "^10.4.1"
+        "constructs": "^10.4.1",
+        "vitest": "^3.2.4"
       }
     },
     "source/lambda": {

--- a/source/constructs/lib/stacks/__snapshots__/capability-insights-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/capability-insights-stack.test.ts.snap
@@ -1,0 +1,905 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CloudFormation template matches snapshot 1`] = `
+{
+  "Parameters": {
+    "ApiAccessSubnetId": {
+      "Description": "ID of Subnet where users will browse Capability Insights website from, calls to back-end API will come from here. A VPC Endpoint to API Gateway will be created in this subnet to enable this.",
+      "Type": "AWS::EC2::Subnet::Id",
+    },
+    "BackendSubnetId": {
+      "Description": "ID of subnet (ideally a private subnet) where the Lambda function will be running.",
+      "Type": "AWS::EC2::Subnet::Id",
+    },
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "DeploymentAssetsBucketApiLambdaFunctionCodeZipPath": {
+      "Default": "lambdaAssets.zip",
+      "Description": "Path in the CapabilityInsights deployment assets bucket where Capability Insights's API Lambda function code zip is located.",
+      "Type": "String",
+    },
+    "DeploymentAssetsBucketName": {
+      "Description": "Name of S3 bucket where Capability Insights deployment assets will be located.",
+      "Type": "String",
+    },
+    "PrivateVpcId": {
+      "Description": "ID of VPC from where the Capability Insights website (hosted on S3 bucket) will be accessible from.",
+      "Type": "AWS::EC2::VPC::Id",
+    },
+    "SourceAccessPointArn": {
+      "Description": "ARN of the S3 access point that provides the capability data source.",
+      "Type": "String",
+    },
+    "SourceFolders": {
+      "AllowedPattern": "^[a-zA-Z0-9_-]+(,[a-zA-Z0-9_-]+)*$",
+      "ConstraintDescription": "Must be a comma-separated list of folder names (letters, numbers, hyphens, underscores). No spaces or trailing commas.",
+      "Default": "public",
+      "Description": "Comma-separated list of folder names in the S3 access point to fetch data from.",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "CapabilityInsightsApiGw": {
+      "Properties": {
+        "Description": "Private REST API for Capability Insights",
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE",
+          ],
+          "VpcEndpointIds": [
+            {
+              "Ref": "CapabilityInsightsApiGwVpcEndpoint",
+            },
+          ],
+        },
+        "Name": "CapabilityInsightsApiGw",
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceVpce": {
+                    "Ref": "CapabilityInsightsApiGwVpcEndpoint",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "CapabilityInsightsApiGwAccessLogGroup": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": [
+            "/aws/apigateway/\${ApiId}/access-logs",
+            {
+              "ApiId": {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsApiGw",
+                  "RestApiId",
+                ],
+              },
+            },
+          ],
+        },
+        "RetentionInDays": 30,
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "CapabilityInsightsApiGwAccount": {
+      "DependsOn": [
+        "CapabilityInsightsApiGwCloudWatchLogsRole",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGwCloudWatchLogsRole",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "CapabilityInsightsApiGwCloudWatchLogsRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsApiGwCloudWatchLogsRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsApiGwDeployment": {
+      "DependsOn": [
+        "CapabilityInsightsApiGwProxyMethod",
+        "CapabilityInsightsApiGwProxyOptionsMethod",
+      ],
+      "Properties": {
+        "Description": "Deployment for CapabilityInsights API Gateway",
+        "RestApiId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGw",
+            "RestApiId",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "CapabilityInsightsApiGwExecutionLogGroup": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": [
+            "API-Gateway-Execution-Logs_\${ApiId}/prod",
+            {
+              "ApiId": {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsApiGw",
+                  "RestApiId",
+                ],
+              },
+            },
+          ],
+        },
+        "RetentionInDays": 30,
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "CapabilityInsightsApiGwProxyMethod": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Sub": [
+              "arn:\${AWS::Partition}:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${LambdaArn}/invocations",
+              {
+                "LambdaArn": {
+                  "Fn::GetAtt": [
+                    "CapabilityInsightsApiLambda",
+                    "Arn",
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "CapabilityInsightsApiGwProxyResource",
+        },
+        "RestApiId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGw",
+            "RestApiId",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "CapabilityInsightsApiGwProxyOptionsMethod": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                "method.response.header.Access-Control-Allow-Methods": "'GET,POST,PUT,DELETE,OPTIONS'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "ResponseTemplates": {
+                "application/json": "",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestTemplates": {
+            "application/json": "{"statusCode": 200}",
+          },
+          "Type": "MOCK",
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+            },
+            "StatusCode": "200",
+          },
+        ],
+        "ResourceId": {
+          "Ref": "CapabilityInsightsApiGwProxyResource",
+        },
+        "RestApiId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGw",
+            "RestApiId",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "CapabilityInsightsApiGwProxyResource": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGw",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "CapabilityInsightsApiGw",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "CapabilityInsightsApiGwSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Security Group for CapabilityInsights API Gateway",
+        "GroupName": "CapabilityInsightsApiGwSecurityGroup",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "VpcId": {
+          "Ref": "PrivateVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "CapabilityInsightsApiGwStage": {
+      "DependsOn": [
+        "CapabilityInsightsApiGwAccount",
+      ],
+      "Properties": {
+        "AccessLogSetting": {
+          "DestinationArn": {
+            "Fn::GetAtt": [
+              "CapabilityInsightsApiGwAccessLogGroup",
+              "Arn",
+            ],
+          },
+          "Format": "$context.requestId $context.extendedRequestId $context.identity.sourceIp $context.requestTime $context.routeKey $context.status",
+        },
+        "DeploymentId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGwDeployment",
+            "DeploymentId",
+          ],
+        },
+        "Description": "Production stage with CloudWatch logging",
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiGw",
+            "RestApiId",
+          ],
+        },
+        "StageName": "prod",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "CapabilityInsightsApiGwVpcEndpoint": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Ref": "CapabilityInsightsApiGwSecurityGroup",
+          },
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.\${AWS::Region}.execute-api",
+        },
+        "SubnetIds": [
+          {
+            "Ref": "ApiAccessSubnetId",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsApiGwVpcEndpoint",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "PrivateVpcId",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "CapabilityInsightsApiLambda": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeploymentAssetsBucketName",
+          },
+          "S3Key": {
+            "Ref": "DeploymentAssetsBucketApiLambdaFunctionCodeZipPath",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_FETCH_LAMBDA_NAME": "CapabilityInsightsDataFetchLambda",
+            "WEBSITE_BUCKET_NAME": {
+              "Ref": "capabilityinsightswebsite",
+            },
+          },
+        },
+        "FunctionName": "CapabilityInsightsApiLambda",
+        "Handler": "api-lambda-main.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsApiLambdaRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs24.x",
+        "Timeout": 60,
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            {
+              "Ref": "CapabilityInsightsApiLambdaSecurityGroup",
+            },
+          ],
+          "SubnetIds": [
+            {
+              "Ref": "BackendSubnetId",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsApiLambdaInvokePermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "CapabilityInsightsApiLambda",
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:\${AWS::Partition}:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${ApiId}/*",
+            {
+              "ApiId": {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsApiGw",
+                  "RestApiId",
+                ],
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "CapabilityInsightsApiLambdaRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/\${FunctionName}:*",
+                      {
+                        "FunctionName": "CapabilityInsightsApiLambda",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "LambdaLogging",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "lambda:InvokeFunction",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${FunctionName}",
+                      {
+                        "FunctionName": "CapabilityInsightsDataFetchLambda",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "InvokeDataFetchLambda",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsApiLambdaRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsApiLambdaSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Security group for CapabilityInsights API Lambda",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": {
+          "Ref": "PrivateVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "CapabilityInsightsDataFetchLambda": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeploymentAssetsBucketName",
+          },
+          "S3Key": {
+            "Ref": "DeploymentAssetsBucketApiLambdaFunctionCodeZipPath",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "DATA_BUCKET_NAME": {
+              "Ref": "capabilityinsightswebsite",
+            },
+            "DATA_BUCKET_PATH": "data",
+            "SOURCE_ACCESS_POINT_ARN": {
+              "Ref": "SourceAccessPointArn",
+            },
+            "SOURCE_FOLDERS": {
+              "Ref": "SourceFolders",
+            },
+          },
+        },
+        "FunctionName": "CapabilityInsightsDataFetchLambda",
+        "Handler": "data-fetch-lambda-main.handler",
+        "MemorySize": 2048,
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsDataFetchLambdaRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs24.x",
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsDataFetchLambdaInvokePermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "CapabilityInsightsDataFetchLambda",
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsDataFetchLambdaScheduleRule",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "CapabilityInsightsDataFetchLambdaRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:GetObject",
+                  ],
+                  "Condition": {
+                    "StringEquals": {
+                      "s3:DataAccessPointAccount": {
+                        "Fn::Select": [
+                          4,
+                          {
+                            "Fn::Split": [
+                              ":",
+                              {
+                                "Ref": "SourceAccessPointArn",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "\${BucketArn}/data/*",
+                      {
+                        "BucketArn": {
+                          "Fn::GetAtt": [
+                            "capabilityinsightswebsite",
+                            "Arn",
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3ReadWritePolicy",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsDataFetchLambdaRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsDataFetchLambdaScheduleRule": {
+      "Properties": {
+        "Description": "Daily trigger for CapabilityInsightsDataFetchLambda lambda function.",
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "CapabilityInsightsDataFetchLambda",
+                "Arn",
+              ],
+            },
+            "Id": "ScheduledLambdaTarget",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CapabilityInsightsLambdaVpcEndpoint": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Ref": "CapabilityInsightsApiGwSecurityGroup",
+          },
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.\${AWS::Region}.lambda",
+        },
+        "SubnetIds": [
+          {
+            "Ref": "BackendSubnetId",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsLambdaVpcEndpoint",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "PrivateVpcId",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "CapabilityInsightsWriteConfigLambda": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "import json
+import boto3
+import cfnresponse
+
+s3 = boto3.client('s3')
+
+def lambda_handler(event, context):
+    try:
+        if event['RequestType'] == 'Delete':
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+            return
+        
+        bucket = event['ResourceProperties']['Bucket']
+        api_url = event['ResourceProperties']['ApiUrl']
+        
+        config = {
+            'apiBaseUrl': api_url
+        }
+        
+        s3.put_object(
+            Bucket=bucket,
+            Key='api-config.json',
+            Body=json.dumps(config),
+            ContentType='application/json'
+        )
+        
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        cfnresponse.send(event, context, cfnresponse.FAILED, {})",
+        },
+        "FunctionName": "CapabilityInsightsWriteConfigLambda",
+        "Handler": "index.lambda_handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsWriteConfigLambdaRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.11",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsWriteConfigLambdaCustomResource": {
+      "Properties": {
+        "ApiUrl": {
+          "Fn::Sub": [
+            "https://\${ApiId}.execute-api.\${AWS::Region}.amazonaws.com/prod",
+            {
+              "ApiId": {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsApiGw",
+                  "RestApiId",
+                ],
+              },
+            },
+          ],
+        },
+        "Bucket": {
+          "Fn::Sub": "capability-insights-website-\${AWS::AccountId}-\${AWS::Region}",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsWriteConfigLambda",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+    },
+    "CapabilityInsightsWriteConfigLambdaRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:\${AWS::Partition}:s3:::capability-insights-website-\${AWS::AccountId}-\${AWS::Region}/*",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3WriteAccess",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsWriteConfigLambdaRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "capabilityinsightswebsite": {
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "BucketName": {
+          "Fn::Sub": "capability-insights-website-\${AWS::AccountId}-\${AWS::Region}",
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "WebsiteConfiguration": {
+          "ErrorDocument": "index.html",
+          "IndexDocument": "index.html",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+    },
+    "capabilityinsightswebsitePolicy": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "capabilityinsightswebsite",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceVpc": {
+                    "Ref": "PrivateVpcId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "capabilityinsightswebsite",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Sub": [
+                    "\${BucketArn}/*",
+                    {
+                      "BucketArn": {
+                        "Fn::GetAtt": [
+                          "capabilityinsightswebsite",
+                          "Arn",
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+              "Sid": "AllowVPCEndpointAccess",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/source/constructs/lib/stacks/__snapshots__/sample-environment-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/sample-environment-stack.test.ts.snap
@@ -1,0 +1,393 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CloudFormation template matches snapshot 1`] = `
+{
+  "Outputs": {
+    "ApiAccessSubnetId": {
+      "Value": {
+        "Fn::GetAtt": [
+          "CapabilityInsightsSampleEnvironmentVpcPublicSubnet",
+          "SubnetId",
+        ],
+      },
+    },
+    "BackendSubnetId": {
+      "Value": {
+        "Fn::GetAtt": [
+          "CapabilityInsightsSampleEnvironmentVpcPrivateSubnet",
+          "SubnetId",
+        ],
+      },
+    },
+    "DeploymentAssetsBucketName": {
+      "Value": {
+        "Ref": "capabilityinsightsassets",
+      },
+    },
+    "PrivateVpcId": {
+      "Value": {
+        "Fn::GetAtt": [
+          "CapabilityInsightsSampleEnvironmentVpc",
+          "VpcId",
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LatestAmazonLinux2023AmiId": {
+      "Default": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+      "Description": "Latest Amazon Linux 2023 AMI ID from SSM Parameter Store",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+    },
+  },
+  "Resources": {
+    "CapabilityInsightsSampleEnvInstanceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": "IAM role for instances in the sample environment VPC.",
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsSampleEnvInstanceRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsSampleEnvironmentVpc": {
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpc",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcIGW": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcIGW",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::InternetGateway",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcIGWRoute": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcIGW",
+            "InternetGatewayId",
+          ],
+        },
+        "RouteTableId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable",
+            "RouteTableId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcIGWVPCAttachment": {
+      "Properties": {
+        "InternetGatewayId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcIGW",
+            "InternetGatewayId",
+          ],
+        },
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPrivateSubnet": {
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.0.0/24",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcPrivateSubnet",
+          },
+        ],
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable",
+          },
+        ],
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPublicSubnet": {
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.1.0/24",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcPublicSubnet",
+          },
+        ],
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPublicSubnetLinuxInstance": {
+      "DependsOn": [
+        "CapabilityInsightsSampleEnvironmentVpcPublicSubnetLinuxInstanceProfile",
+      ],
+      "Properties": {
+        "IamInstanceProfile": "CapabilityInsightsSampleEnvironmentVpcPublicSubnetLinuxInstanceProfile",
+        "ImageId": {
+          "Ref": "LatestAmazonLinux2023AmiId",
+        },
+        "InstanceType": "t3.micro",
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "CapabilityInsightsSampleEnvironmentVpcSSHSG",
+              "GroupId",
+            ],
+          },
+        ],
+        "SubnetId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcPublicSubnet",
+            "SubnetId",
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcPublicSubnetLinuxInstance",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::Instance",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPublicSubnetLinuxInstanceProfile": {
+      "DependsOn": [
+        "CapabilityInsightsSampleEnvInstanceRole",
+      ],
+      "Properties": {
+        "InstanceProfileName": "CapabilityInsightsSampleEnvironmentVpcPublicSubnetLinuxInstanceProfile",
+        "Roles": [
+          {
+            "Fn::Sub": "CapabilityInsightsSampleEnvInstanceRole-\${AWS::Region}",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPublicSubnetRouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable",
+            "RouteTableId",
+          ],
+        },
+        "SubnetId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcPublicSubnet",
+            "SubnetId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcS3Endpoint": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": {
+                "Fn::Sub": "arn:\${AWS::Partition}:s3:::capability-insights-website-\${AWS::AccountId}-\${AWS::Region}/*",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "RouteTableIds": [
+          {
+            "Fn::GetAtt": [
+              "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable",
+              "RouteTableId",
+            ],
+          },
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.\${AWS::Region}.s3",
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcS3Endpoint",
+          },
+        ],
+        "VpcEndpointType": "Gateway",
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcSSHSG": {
+      "Properties": {
+        "GroupDescription": "Security Group for the CapabilityInsightsSampleEnvironmentVpc vpc that allows incoming SSH connections.",
+        "GroupName": "CapabilityInsightsSampleEnvironmentVpcSSHSG",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow incoming SSH from anywhere",
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "ToPort": 22,
+          },
+        ],
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "capabilityinsightsassets": {
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "BucketName": {
+          "Fn::Sub": "capability-insights-assets-\${AWS::AccountId}-\${AWS::Region}",
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/source/constructs/lib/stacks/capability-insights-stack.test.ts
+++ b/source/constructs/lib/stacks/capability-insights-stack.test.ts
@@ -1,0 +1,26 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { afterAll, expect, test } from 'vitest';
+import { CapabilityInsightsStack } from './capability-insights-stack';
+
+let snapshotFailed = false;
+
+test('CloudFormation template matches snapshot', () => {
+  const app = new App();
+  const stack = new CapabilityInsightsStack(app, 'TestStack');
+  try {
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  } catch (e) {
+    snapshotFailed = true;
+    throw e;
+  }
+});
+
+afterAll(() => {
+  if (snapshotFailed) {
+    console.error(
+      '\n📸 Snapshot mismatch! If this change is intentional, update with:\n' +
+        '   npm run test:update-snapshot --workspace=source/constructs\n',
+    );
+  }
+});

--- a/source/constructs/lib/stacks/sample-environment-stack.test.ts
+++ b/source/constructs/lib/stacks/sample-environment-stack.test.ts
@@ -1,0 +1,26 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { afterAll, expect, test } from 'vitest';
+import { CapabilityInsightsSampleEnvironmentStack } from './sample-environment-stack';
+
+let snapshotFailed = false;
+
+test('CloudFormation template matches snapshot', () => {
+  const app = new App();
+  const stack = new CapabilityInsightsSampleEnvironmentStack(app, 'TestStack');
+  try {
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  } catch (e) {
+    snapshotFailed = true;
+    throw e;
+  }
+});
+
+afterAll(() => {
+  if (snapshotFailed) {
+    console.error(
+      '\n📸 Snapshot mismatch! If this change is intentional, update with:\n' +
+        '   npm run test:update-snapshot --workspace=source/constructs\n',
+    );
+  }
+});

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -9,16 +9,17 @@
     "clean": "rm -rf build cdk.out dist",
     "build": "tsc",
     "package": "npx cdk synth --output build/cdk.out --quiet && node scripts/package-template.mjs",
-    "test": "echo OK",
+    "test": "vitest run",
+    "test:update-snapshot": "vitest run -u",
     "lint": "eslint --cache lib && prettier --check --cache .",
     "format": "eslint --fix --cache lib && prettier --write --cache .",
     "dev-build": "tsc && node dist/bin/dev"
   },
-  "dependencies": {},
   "devDependencies": {
     "@tsconfig/node-lts": "^20.1.3",
     "aws-cdk": "^2.1106.1",
     "aws-cdk-lib": "^2.245.0",
-    "constructs": "^10.4.1"
+    "constructs": "^10.4.1",
+    "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary (required)

Adds Vitest snapshot tests for both CDK stacks to catch unintended CloudFormation template changes.

## Details (required)

The `source/constructs` workspace had no real tests (`"test": "echo OK"`). This PR adds snapshot tests that synthesize each CDK stack and compare the resulting CloudFormation template against a saved `.snap` file. Any infrastructure drift causes the test to fail with a clear diff.

**Changes:**
- Added `vitest` as a dev dependency in `source/constructs`
- Updated test script from `echo OK` to `vitest run`
- Added `test:update-snapshot` script for accepting intentional CDK changes
- Added snapshot tests for `CapabilityInsightsStack` and `CapabilityInsightsSampleEnvironmentStack`
- On snapshot mismatch, a hint is printed with the exact command to update

When changes are intentional, run: `npm run test:update-snapshot --workspace=source/constructs`

## Testing (required)

Check all that apply:

- [x] Unit tests
- [ ] Local development server
- [ ] Full deployment

**How did you test this?**

- Ran `npm test --workspace=source/constructs` — both snapshot tests pass
- Verified snapshot failure by modifying a stack parameter description, confirmed the test fails with a clear diff showing the exact change
- Verified snapshot update flow with `npm run test:update-snapshot --workspace=source/constructs`

## Screenshots

N/A — no UI changes.

## ⚠️ Branch Target

> All PRs must target the **`development`** branch. PRs opened against `main` will be closed.

## Versioning & Releases

When changes are merged to `main`, the release workflow automatically builds and publishes a [GitHub Release](https://github.com/aws/capability-insights-for-aws/releases) with deployment artifacts (`build-assets.zip`).

- If the version in `package.json` hasn't changed, the existing release is overwritten with fresh artifacts.
- If the version is bumped, a new release is created and previous versions remain available.

Bump the `version` in `package.json` when you want to cut a new release:

- **Patch** (1.0.0 → 1.0.1): Bug fixes, dependency updates, docs changes
- **Minor** (1.0.0 → 1.1.0): New features, non-breaking changes
- **Major** (1.0.0 → 2.0.0): Breaking changes (e.g., new required CloudFormation parameters)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.