### PR TITLE
fix: restrict data fetch lambda to AP arn

### DIFF
--- a/source/constructs/lib/stacks/__snapshots__/capability-insights-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/capability-insights-stack.test.ts.snap
@@ -580,23 +580,11 @@ exports[`CloudFormation template matches snapshot 1`] = `
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": [
-                    "s3:GetObject",
-                  ],
+                  "Action": "s3:GetObject",
                   "Condition": {
                     "StringEquals": {
-                      "s3:DataAccessPointAccount": {
-                        "Fn::Select": [
-                          4,
-                          {
-                            "Fn::Split": [
-                              ":",
-                              {
-                                "Ref": "SourceAccessPointArn",
-                              },
-                            ],
-                          },
-                        ],
+                      "s3:DataAccessPointArn": {
+                        "Ref": "SourceAccessPointArn",
                       },
                     },
                   },

--- a/source/constructs/lib/stacks/capability-insights-stack.ts
+++ b/source/constructs/lib/stacks/capability-insights-stack.ts
@@ -209,14 +209,11 @@ export class CapabilityInsightsStack extends cdk.Stack {
             Statement: [
               {
                 Effect: 'Allow',
-                Action: ['s3:GetObject'],
+                Action: 's3:GetObject',
                 Resource: '*',
                 Condition: {
                   StringEquals: {
-                    's3:DataAccessPointAccount': cdk.Fn.select(
-                      4,
-                      cdk.Fn.split(':', sourceAccessPointArnParameter.valueAsString),
-                    ),
+                    's3:DataAccessPointArn': sourceAccessPointArnParameter.valueAsString,
                   },
                 },
               },


### PR DESCRIPTION
Change the DataFetch Lambda S3 read policy condition from `s3:DataAccessPointAccount` to `s3:DataAccessPointArn`, using the `SourceAccessPointArn` parameter value.