### PR TITLE
feat: personalization layer (Usage Analysis + My Stuff) — v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The dashboard covers:
 - **Services and features** — availability status, expected launch dates, and expansion plans per region
 - **API operations** — individual API action availability per region for each AWS service
 - **CloudFormation resource types** — which resource types are supported in each region
+- **Personalized usage (opt-in)** — a "My Stuff" view that filters everything down to services, APIs, and resources actually used in your account, derived from CloudTrail and CloudFormation
 
 ![Dashboard overview](docs/images/dashboard-overview.png)
 
@@ -37,7 +38,7 @@ The solution deploys entirely within your VPC so that all data remains within yo
 
 ![High-level architecture](docs/images/high-level-architecture.png)
 
-The solution deploys a static website, REST API, and Lambda functions into your VPC. For a detailed breakdown of all resources, see [Architecture](#architecture).
+The solution deploys a static website, REST API, and Lambda functions into your VPC. Personalization is provided by an opt-in second stack that adds a Step Functions state machine and analyzer Lambdas that read your account's CloudTrail logs and CloudFormation stacks. For a detailed breakdown of all resources, see [Architecture](#architecture).
 
 ## Installation
 
@@ -112,7 +113,8 @@ npm run deploy -- \
   --api-access-subnet-id subnet-0def456 \
   --deployment-assets-bucket-name my-deploy-bucket \
   --source-access-point-arn arn:aws:s3:us-east-1:123456789012:accesspoint/my-access-point \
-  --source-folders aws-cn,public
+  --source-folders aws-cn,public \
+  --enable-usage-analysis
 ```
 
 | Flag                              | Description                                                                                                             |
@@ -123,6 +125,8 @@ npm run deploy -- \
 | `--deployment-assets-bucket-name` | S3 bucket where deployment assets (Lambda code zip) are stored.                                                         |
 | `--source-access-point-arn`       | S3 access point ARN for the capability data source (provided during onboarding).                                        |
 | `--source-folders`                | Comma-separated list of data sources to pull from (default: `public`). Include additional partitions if granted access. |
+| `--enable-usage-analysis`         | Deploy the opt-in Usage Analysis stack to enable personalization.                                                       |
+| `--cloudtrail-bucket`             | CloudTrail logs bucket used by the analyzer (only with `--enable-usage-analysis`). Auto-discovered if omitted.          |
 
 #### Teardown
 
@@ -238,6 +242,12 @@ Open the side navigation to switch between the Capability by Region dashboard an
 
 ![Settings](docs/images/user-guide-settings.png)
 
+### Personalizing the dashboard (opt-in)
+
+If you deployed with `--enable-usage-analysis`, the dashboard offers a **My Stuff** toggle that filters services, APIs, and CloudFormation resources to only what's actually used in your account. The data is produced by analyzers that read your CloudTrail logs and active CloudFormation stacks, then written back to the website bucket as a personalized data set.
+
+The analysis runs on a daily schedule. You can also trigger it on demand from the Settings page using the **Run usage analysis** button. The page shows progress and the result counts when the run completes; refresh the dashboard afterwards to see the updated personalization.
+
 ## Architecture
 
 This repository provides two CloudFormation stacks:
@@ -271,6 +281,20 @@ A development stack that mimics a customer environment for testing. Customers de
 | EC2 Instance (Linux)      | Amazon Linux 2023 instance for testing            |
 | IAM Role                  | Instance role with SSM and S3 access              |
 
+### Usage Analysis Stack (opt-in)
+
+Adds personalization. Deployed when you pass `--enable-usage-analysis` to `npm run deploy`. Reads CloudTrail logs (via Athena) and active CloudFormation stacks to build a per-account view of services, APIs, and CloudFormation resources that are actually in use, then writes a personalized data set back to the website bucket. The dashboard's "My Stuff" toggle reads that data set.
+
+| Resource                       | Description                                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| Step Functions State Machine   | Orchestrates the analyzers in parallel and runs the decorator                              |
+| CloudTrail Analyzer Lambda     | Queries CloudTrail logs in Athena and emits per-service usage records                      |
+| CloudFormation Analyzer Lambda | Lists active CloudFormation stacks and emits per-resource records                          |
+| Usage Decorator Lambda         | Joins analyzer output with the master capability catalog and writes the personalized files |
+| Glue Database / Table          | Schema over the CloudTrail bucket so the analyzer can run Athena queries                   |
+| Lake Formation Permissions     | Grants the analyzer role read access to the Glue database                                  |
+| EventBridge Rule               | Schedules the state machine to run daily (configurable via `AnalysisSchedule` parameter)   |
+
 ### Package Structure
 
 This project uses [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces) to manage four packages under `source/`.
@@ -297,6 +321,7 @@ CDK application that defines the two CloudFormation stacks. We use CDK as a deve
 
 - **API Lambda** (`api-lambda-main.ts`): Backs the API Gateway and routes requests from the website.
 - **DataFetch Lambda** (`data-fetch-lambda-main.ts`): Reads capability data from the source S3 access point, merges data across multiple source folders, and writes the results to the website bucket in both JSON and CSV formats.
+- **CloudTrail Analyzer** (`cloudtrail-analyzer.ts`), **CloudFormation Analyzer** (`cloudformation-analyzer.ts`), **Usage Decorator** (`usage-decorator.ts`): Power the opt-in Usage Analysis stack. Triggered by a Step Functions state machine that runs the two analyzers in parallel, then the decorator merges their output with the master catalog into personalized files for the dashboard's "My Stuff" view.
 
 #### `source/website`
 
@@ -326,7 +351,12 @@ npm run dev:setup -- --ec2-key-pair ci-key
 
 # Deploy Capability Insights using the CapabilityInsightsSampleEnvironment outputs
 npm run dev:deploy
+
+# Or, to also deploy the opt-in Usage Analysis stack for personalization:
+npm run dev:deploy -- --enable-usage-analysis
 ```
+
+`--enable-usage-analysis` auto-discovers the CloudTrail bucket from your account. Pass `--cloudtrail-bucket <name>` to override.
 
 ### Available Scripts
 

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -19,6 +19,9 @@ Deploy options (pass as flags or omit to be prompted):
   --deployment-assets-bucket-name <name> S3 bucket for deployment assets
   --source-access-point-arn <arn>        S3 access point ARN for capability data source
   --source-folders <folders>             Comma-separated list of source folders (default: public)
+  --enable-usage-analysis                Deploy the Usage Analysis stack
+  --cloudtrail-bucket <name>             S3 bucket containing CloudTrail logs (for usage analysis,
+                                         auto-discovered from your account's CloudTrail trails if omitted)
   -y, --yes                              Skip confirmation prompts
 
 Examples:
@@ -56,7 +59,7 @@ prompt_if_empty() {
 }
 
 cmd_deploy() {
-  local private_vpc_id="" backend_subnet_id="" api_access_subnet_id="" deployment_assets_bucket_name="" source_access_point_arn="" source_folders="" auto_approve=""
+  local private_vpc_id="" backend_subnet_id="" api_access_subnet_id="" deployment_assets_bucket_name="" source_access_point_arn="" source_folders="" cloudtrail_bucket="" enable_usage_analysis="" auto_approve=""
 
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -66,6 +69,8 @@ cmd_deploy() {
       --deployment-assets-bucket-name)   deployment_assets_bucket_name="$2"; shift 2 ;;
       --source-access-point-arn)         source_access_point_arn="$2"; shift 2 ;;
       --source-folders)                  source_folders="$2"; shift 2 ;;
+      --cloudtrail-bucket)               cloudtrail_bucket="$2"; shift 2 ;;
+      --enable-usage-analysis)           enable_usage_analysis="true"; shift ;;
       -y|--yes)                          auto_approve="true"; shift ;;
       *) echo "Unknown option: $1"; usage ;;
     esac
@@ -90,6 +95,28 @@ cmd_deploy() {
       source_folders="public"
     fi
   done
+
+  # Auto-discover a CloudTrail bucket when --enable-usage-analysis is set
+  # but --cloudtrail-bucket was not. Queries CloudTrail directly for the
+  # account's configured trails and pulls the S3 bucket from the matching
+  # one. If multiple match, list and prompt; if none, prompt with a hint.
+  if [[ "$enable_usage_analysis" == "true" && -z "$cloudtrail_bucket" ]]; then
+    local discovered_buckets
+    discovered_buckets=$(aws cloudtrail describe-trails --query 'trailList[].S3BucketName' --output text 2>/dev/null | tr '\t' '\n' | grep -v '^$' | sort -u || true)
+    local discovered_count
+    discovered_count=$(printf '%s\n' "$discovered_buckets" | grep -c . || true)
+    if [[ "$discovered_count" == "1" ]]; then
+      cloudtrail_bucket="$discovered_buckets"
+      echo "Auto-discovered CloudTrail bucket: $cloudtrail_bucket"
+    elif [[ "$discovered_count" -gt 1 ]]; then
+      echo "Multiple CloudTrail buckets found:"
+      printf '  %s\n' $discovered_buckets
+      prompt_if_empty cloudtrail_bucket "CloudTrailBucket (paste one of the above)"
+    else
+      echo "No CloudTrail trails found in this account/region. Configure CloudTrail to log to S3, or pass --cloudtrail-bucket explicitly."
+      prompt_if_empty cloudtrail_bucket "CloudTrailBucket"
+    fi
+  fi
 
   echo ""
   echo "Deploying to account $AWS_ACCOUNT in $AWS_REGION"
@@ -150,7 +177,83 @@ cmd_deploy() {
   echo "── Uploading website assets ──"
   get_account_and_region
   local website_bucket="capability-insights-website-${ACCOUNT_ID}-${REGION}"
+  local website_bucket_arn="arn:aws:s3:::${website_bucket}"
   aws s3 sync "$SCRIPT_DIR/dist/website/" "s3://$website_bucket/"
+
+  echo "── Deploying Usage Analysis stack ──"
+  if [[ "$enable_usage_analysis" == "true" ]]; then
+    aws cloudformation deploy \
+      --template-file "$SCRIPT_DIR/dist/template/usage-analysis.template.json" \
+      --stack-name CapabilityInsightsUsageAnalysis \
+      --parameter-overrides \
+        WebsiteBucketName="$website_bucket" \
+        WebsiteBucketArn="$website_bucket_arn" \
+        DeploymentAssetsBucketName="$deployment_assets_bucket_name" \
+        LambdaCodeZipPath="$lambda_key" \
+        CloudTrailBucketName="${cloudtrail_bucket:-}" \
+      --capabilities CAPABILITY_NAMED_IAM \
+      --no-cli-pager || true
+    echo "  ✓ Usage Analysis stack deployed."
+
+    # Get outputs from Usage Analysis stack
+    local analysis_state_machine_arn cloudtrail_analyzer_lambda_name cloudformation_analyzer_lambda_name usage_decorator_lambda_name
+    analysis_state_machine_arn=$(aws cloudformation describe-stacks \
+      --stack-name CapabilityInsightsUsageAnalysis \
+      --query "Stacks[0].Outputs[?OutputKey=='AnalysisStateMachineArn'].OutputValue" --output text 2>/dev/null || echo "")
+    cloudtrail_analyzer_lambda_name=$(aws cloudformation describe-stacks \
+      --stack-name CapabilityInsightsUsageAnalysis \
+      --query "Stacks[0].Outputs[?OutputKey=='CloudTrailAnalyzerLambdaName'].OutputValue" --output text 2>/dev/null || echo "")
+    cloudformation_analyzer_lambda_name=$(aws cloudformation describe-stacks \
+      --stack-name CapabilityInsightsUsageAnalysis \
+      --query "Stacks[0].Outputs[?OutputKey=='CloudFormationAnalyzerLambdaName'].OutputValue" --output text 2>/dev/null || echo "")
+    usage_decorator_lambda_name=$(aws cloudformation describe-stacks \
+      --stack-name CapabilityInsightsUsageAnalysis \
+      --query "Stacks[0].Outputs[?OutputKey=='UsageDecoratorLambdaName'].OutputValue" --output text 2>/dev/null || echo "")
+
+    # Force Lambda code update (CloudFormation may skip if template is unchanged)
+    if [[ -n "$cloudtrail_analyzer_lambda_name" ]]; then
+      aws lambda update-function-code \
+        --function-name "$cloudtrail_analyzer_lambda_name" \
+        --s3-bucket "$deployment_assets_bucket_name" \
+        --s3-key "$lambda_key" > /dev/null 2>&1 || true
+    fi
+    if [[ -n "$cloudformation_analyzer_lambda_name" ]]; then
+      aws lambda update-function-code \
+        --function-name "$cloudformation_analyzer_lambda_name" \
+        --s3-bucket "$deployment_assets_bucket_name" \
+        --s3-key "$lambda_key" > /dev/null 2>&1 || true
+    fi
+    if [[ -n "$usage_decorator_lambda_name" ]]; then
+      aws lambda update-function-code \
+        --function-name "$usage_decorator_lambda_name" \
+        --s3-bucket "$deployment_assets_bucket_name" \
+        --s3-key "$lambda_key" > /dev/null 2>&1 || true
+    fi
+
+    if [[ -n "$analysis_state_machine_arn" && -n "$cloudtrail_analyzer_lambda_name" && -n "$cloudformation_analyzer_lambda_name" ]]; then
+      echo "── Updating Insights stack with Usage Analysis outputs ──"
+      aws cloudformation deploy \
+        --template-file "$SCRIPT_DIR/dist/template/capability-insights.template.json" \
+        --stack-name CapabilityInsightsForAWS \
+        --parameter-overrides \
+          PrivateVpcId="$private_vpc_id" \
+          BackendSubnetId="$backend_subnet_id" \
+          ApiAccessSubnetId="$api_access_subnet_id" \
+          DeploymentAssetsBucketName="$deployment_assets_bucket_name" \
+          DeploymentAssetsBucketApiLambdaFunctionCodeZipPath="$lambda_key" \
+          SourceAccessPointArn="$source_access_point_arn" \
+          SourceFolders="$source_folders" \
+          AnalysisStateMachineArn="$analysis_state_machine_arn" \
+          CloudTrailAnalyzerLambdaName="$cloudtrail_analyzer_lambda_name" \
+          CloudFormationAnalyzerLambdaName="$cloudformation_analyzer_lambda_name" \
+          ConfiguredCloudTrailBucketName="$cloudtrail_bucket" \
+        --capabilities CAPABILITY_NAMED_IAM \
+        --no-cli-pager || true
+      echo "  ✓ Insights stack updated with analysis integration."
+    fi
+  else
+    echo "  Skipped (pass --enable-usage-analysis to deploy)."
+  fi
 
   echo "── Syncing capability data ──"
   aws lambda invoke --function-name CapabilityInsightsDataFetchLambda --invocation-type Event /dev/null > /dev/null 2>&1
@@ -169,13 +272,18 @@ cmd_teardown() {
   local website_bucket="capability-insights-website-${ACCOUNT_ID}-${REGION}"
 
   if [[ "$AUTO_APPROVE" != "true" ]]; then
-    echo "This will delete the CapabilityInsightsForAWS stack and empty the website bucket."
+    echo "This will delete the CapabilityInsightsForAWS and CapabilityInsightsUsageAnalysis stacks and empty the website bucket."
     read -rp "Continue? (y/N): " confirm
     [[ "$confirm" =~ ^[Yy]$ ]] || exit 0
   fi
 
   echo "── Emptying website bucket ──"
   aws s3 rm "s3://$website_bucket" --recursive || true
+
+  echo "── Destroying Usage Analysis stack ──"
+  aws cloudformation delete-stack --stack-name CapabilityInsightsUsageAnalysis 2>/dev/null || true
+  aws cloudformation wait stack-delete-complete --stack-name CapabilityInsightsUsageAnalysis 2>/dev/null || true
+  echo "  ✓ Usage Analysis stack deleted."
 
   echo "── Destroying stack (this will likely take ~15 minutes) ──"
   aws cloudformation delete-stack --stack-name CapabilityInsightsForAWS

--- a/deployment/dev.sh
+++ b/deployment/dev.sh
@@ -21,6 +21,9 @@ Setup options:
 Deploy options:
   --source-access-point-arn <arn>  S3 access point ARN for capability data source
   --source-folders <folders>       Comma-separated list of source folders (default: public)
+  --enable-usage-analysis          Also deploy the opt-in Usage Analysis stack
+  --cloudtrail-bucket <name>       CloudTrail logs bucket (only with --enable-usage-analysis,
+                                   auto-discovered from your account if omitted)
 
 Global options:
   -y, --yes                        Skip confirmation prompts
@@ -60,11 +63,13 @@ cmd_setup() {
 }
 
 cmd_deploy() {
-  local source_access_point_arn="" source_folders=""
+  local source_access_point_arn="" source_folders="" enable_usage_analysis="" cloudtrail_bucket=""
   while [[ $# -gt 0 ]]; do
     case $1 in
       --source-access-point-arn) source_access_point_arn="$2"; shift 2 ;;
       --source-folders) source_folders="$2"; shift 2 ;;
+      --enable-usage-analysis) enable_usage_analysis="true"; shift ;;
+      --cloudtrail-bucket) cloudtrail_bucket="$2"; shift 2 ;;
       -y|--yes) shift ;;
       *) echo "Unknown option: $1"; usage ;;
     esac
@@ -96,12 +101,21 @@ cmd_deploy() {
     access_point_args+=(--source-folders "$source_folders")
   fi
 
+  local usage_analysis_args=()
+  if [[ "$enable_usage_analysis" == "true" ]]; then
+    usage_analysis_args+=(--enable-usage-analysis)
+    if [[ -n "$cloudtrail_bucket" ]]; then
+      usage_analysis_args+=(--cloudtrail-bucket "$cloudtrail_bucket")
+    fi
+  fi
+
   local deploy_args=(
     --private-vpc-id "$private_vpc_id"
     --backend-subnet-id "$backend_subnet_id"
     --api-access-subnet-id "$api_access_subnet_id"
     --deployment-assets-bucket-name "$deployment_assets_bucket_name"
     "${access_point_args[@]}"
+    "${usage_analysis_args[@]}"
   )
   [[ -n "$AUTO_APPROVE" ]] && deploy_args+=(--yes)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -295,6 +295,109 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-athena": {
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1040.0.tgz",
+      "integrity": "sha512-rKew6XfzXYtEwbOvCYEW+ByvmcTeF2H0j3SASF11SPusxzfjDZXfEM9VJzHwayDZAIciVFtxLoTFRhjGJql2yw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/credential-provider-node": "^3.972.38",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1040.0.tgz",
+      "integrity": "sha512-dz49RtTM+RJlZBJW3f+tyl83kxkeEC9rOQPIhKJU8LPC6jONcTWp/BK53uTwUaLt673z6OfX9jgOCPcJ8zwtaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/credential-provider-node": "^3.972.38",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.1020.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1020.0.tgz",
@@ -345,6 +448,57 @@
         "@smithy/util-stream": "^4.5.21",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-organizations": {
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.1040.0.tgz",
+      "integrity": "sha512-LlMYtN+8/1hXMpJG1PiLC4+96ir0hoLuOb7pqK4HyQI3Rw1MYg89IXVfDqy0eCpwC9Z0nkJchhIEsiEyuOiCGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/credential-provider-node": "^3.972.38",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -418,24 +572,128 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.973.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
-      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+    "node_modules/@aws-sdk/client-sfn": {
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.1040.0.tgz",
+      "integrity": "sha512-f9pig1Y2AGA95GgX3679c2xz5PGS6m3Tg62i0K1+C78SoDJ+kDASZ/muUHME/AFSIUaLdGHPdv+/qUcA3fXIZA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/credential-provider-node": "^3.972.38",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1040.0.tgz",
+      "integrity": "sha512-k5m8ofhqQ2102h6l0iqNFRpuSXdyhk62U9i13kmGmscfqtVX4JeKjg//IK1Mhaz6Owi6WxAl1jQ8vcx81gpzww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/credential-provider-node": "^3.972.38",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.24",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.7.tgz",
+      "integrity": "sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -458,16 +716,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
-      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.33.tgz",
+      "integrity": "sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -475,21 +733,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
-      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.35.tgz",
+      "integrity": "sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -497,25 +755,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.27.tgz",
-      "integrity": "sha512-Um26EsNSUfVUX0wUXnUA1W3wzKhVy6nviEElsh5lLZUYj9bk6DXOPnpte0gt+WHubcVfVsRk40bbm4KaroTEag==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.37.tgz",
+      "integrity": "sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-login": "^3.972.27",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.27",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.27",
-        "@aws-sdk/nested-clients": "^3.996.17",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/credential-provider-env": "^3.972.33",
+        "@aws-sdk/credential-provider-http": "^3.972.35",
+        "@aws-sdk/credential-provider-login": "^3.972.37",
+        "@aws-sdk/credential-provider-process": "^3.972.33",
+        "@aws-sdk/credential-provider-sso": "^3.972.37",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.37",
+        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -523,19 +781,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.27.tgz",
-      "integrity": "sha512-t3ehEtHomGZwg5Gixw4fYbYtG9JBnjfAjSDabxhPEu/KLLUp0BB37/APX7MSKXQhX6ZH7pseuACFJ19NrAkNdg==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.37.tgz",
+      "integrity": "sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.17",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -543,23 +801,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.28.tgz",
-      "integrity": "sha512-rren+P6k5rShG5PX61iVi40kKdueyuMLBRTctQbyR5LooO9Ygr5L6R7ilG7RF1957NSH3KC3TU206fZuKwjSpQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.38.tgz",
+      "integrity": "sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-ini": "^3.972.27",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.27",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.27",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.33",
+        "@aws-sdk/credential-provider-http": "^3.972.35",
+        "@aws-sdk/credential-provider-ini": "^3.972.37",
+        "@aws-sdk/credential-provider-process": "^3.972.33",
+        "@aws-sdk/credential-provider-sso": "^3.972.37",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -567,17 +825,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
-      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.33.tgz",
+      "integrity": "sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -585,19 +843,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.27.tgz",
-      "integrity": "sha512-CWXeGjlbBuHcm9appZUgXKP2zHDyTti0/+gXpSFJ2J3CnSwf1KWjicjN0qG2ozkMH6blrrzMrimeIOEYNl238Q==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.37.tgz",
+      "integrity": "sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.17",
-        "@aws-sdk/token-providers": "3.1020.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/token-providers": "3.1039.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -605,18 +863,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.27.tgz",
-      "integrity": "sha512-CUY4hQIFswdQNEsRGEzGBUKGMK5KpqmNDdu2ROMgI+45PLFS8H0y3Tm7kvM16uvvw3n1pVxk85tnRVUTgtaa1w==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.37.tgz",
+      "integrity": "sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.17",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -685,15 +943,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -716,14 +974,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -731,16 +989,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -748,24 +1006,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
-      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.36.tgz",
+      "integrity": "sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -789,19 +1047,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.27.tgz",
-      "integrity": "sha512-TIRLO5UR2+FVUGmhYoAwVkKhcVzywEDX/5LzR9tjy1h8FQAXOtFg2IqgmwvxU7y933rkTn9rl6AdgcAUgQ1/Kg==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.37.tgz",
+      "integrity": "sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-retry": "^4.2.12",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -809,48 +1067,49 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.17.tgz",
-      "integrity": "sha512-7B0HIX0tEFmOSJuWzdHZj1WhMXSryM+h66h96ZkqSncoY7J6wq61KOu4Kr57b/YnJP3J/EeQYVFulgR281h+7A==",
+      "version": "3.997.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.5.tgz",
+      "integrity": "sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.27",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.13",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.45",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.24",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -859,16 +1118,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -876,17 +1135,17 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
-      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
+      "version": "3.996.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz",
+      "integrity": "sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -894,18 +1153,18 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1020.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1020.0.tgz",
-      "integrity": "sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw==",
+      "version": "3.1039.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
+      "integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.17",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -913,13 +1172,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -940,16 +1199,16 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -970,29 +1229,29 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.13.tgz",
-      "integrity": "sha512-s1dCJ0J9WU9UPkT3FFqhKTSquYTkqWXGRaapHFyWwwJH86ZussewhNST5R5TwXVL1VSHq4aJVl9fWK+svaRVCQ==",
+      "version": "3.973.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.23.tgz",
+      "integrity": "sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.27",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1009,14 +1268,15 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2410,6 +2670,19 @@
       "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
       "license": "MIT"
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@react-router/dev": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.13.2.tgz",
@@ -2904,6 +3177,47 @@
         "win32"
       ]
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
@@ -2932,17 +3246,17 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
-      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2950,19 +3264,19 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.13",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
-      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -2972,16 +3286,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3064,15 +3378,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -3097,13 +3411,13 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
-      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -3128,13 +3442,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
-      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3170,14 +3484,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
-      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3185,19 +3499,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.28",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
-      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3205,19 +3519,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.45",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.45.tgz",
-      "integrity": "sha512-td1PxpwDIaw5/oP/xIRxBGxJKoF1L4DBAwbZ8wjMuXBYOP/r2ZE/Ocou+mBHx/yk9knFEtDBwhSrYVn+Mz4pHw==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -3226,15 +3541,15 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
-      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3242,13 +3557,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
-      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3256,15 +3571,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
-      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3272,15 +3587,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
-      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3288,13 +3603,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
-      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3302,13 +3617,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3316,13 +3631,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
-      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -3331,13 +3646,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
-      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3345,26 +3660,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
-      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
-      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3372,17 +3687,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -3392,18 +3707,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
-      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3411,9 +3726,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3424,14 +3739,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
-      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3507,15 +3822,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.44",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
-      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3523,18 +3838,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
-      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3542,14 +3857,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
-      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3570,13 +3885,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
-      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3584,14 +3899,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
-      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+      "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3599,15 +3914,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
-      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/types": "^4.13.1",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -3646,13 +3961,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.14.tgz",
-      "integrity": "sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3711,6 +4026,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3747,6 +4069,23 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -4254,7 +4593,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -4714,6 +5052,18 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/babel-dead-code-elimination": {
@@ -5296,6 +5646,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -5752,9 +6112,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "dev": true,
       "funding": [
         {
@@ -5768,9 +6128,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "dev": true,
       "funding": [
         {
@@ -5780,9 +6140,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6221,7 +6582,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6276,6 +6636,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6557,6 +6924,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -6702,9 +7103,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "dev": true,
       "funding": [
         {
@@ -7293,6 +7694,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7379,9 +7799,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {
@@ -7525,6 +7945,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-is": {
@@ -7957,10 +8387,20 @@
     "source/lambda": {
       "name": "@capability-insights/lambda",
       "version": "1.0.0",
+      "dependencies": {
+        "js-yaml": "4.1.1"
+      },
       "devDependencies": {
-        "@aws-sdk/client-lambda": "^3.1001.0",
-        "@aws-sdk/client-s3": "^3.997.0",
+        "@aws-sdk/client-athena": "3.1040.0",
+        "@aws-sdk/client-cloudformation": "3.1040.0",
+        "@aws-sdk/client-lambda": "3.1020.0",
+        "@aws-sdk/client-organizations": "3.1040.0",
+        "@aws-sdk/client-s3": "3.1020.0",
+        "@aws-sdk/client-sfn": "3.1040.0",
+        "@aws-sdk/client-sts": "3.1040.0",
         "@types/aws-lambda": "^8.10.160",
+        "@types/js-yaml": "^4.0.9",
+        "aws-sdk-client-mock": "^4.0.0",
         "vitest": "^3.2.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/source/constructs/bin/app.ts
+++ b/source/constructs/bin/app.ts
@@ -1,5 +1,7 @@
 import { App } from 'aws-cdk-lib';
 import { CapabilityInsightsStack } from '../lib/stacks/capability-insights-stack';
+import { UsageAnalysisStack } from '../lib/stacks/usage-analysis-stack';
 
 const app = new App();
 new CapabilityInsightsStack(app, 'CapabilityInsightsForAWS');
+new UsageAnalysisStack(app, 'CapabilityInsightsUsageAnalysis');

--- a/source/constructs/lib/index.ts
+++ b/source/constructs/lib/index.ts
@@ -1,5 +1,10 @@
-export { CapabilityInsightsStack, CapabilityInsightsStackProps } from './stacks/capability-insights-stack';
+export {
+  CapabilityInsightsStack,
+  CapabilityInsightsStackProps,
+  CapabilityInsightsStackOutputs,
+} from './stacks/capability-insights-stack';
 export {
   CapabilityInsightsSampleEnvironmentStack,
   CapabilityInsightsSampleEnvironmentOutputs,
 } from './stacks/sample-environment-stack';
+export { UsageAnalysisStack, UsageAnalysisStackProps, UsageAnalysisStackOutputs } from './stacks/usage-analysis-stack';

--- a/source/constructs/lib/stacks/__snapshots__/capability-insights-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/capability-insights-stack.test.ts.snap
@@ -2,7 +2,41 @@
 
 exports[`CloudFormation template matches snapshot 1`] = `
 {
+  "Conditions": {
+    "HasAnalysisStateMachine": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AnalysisStateMachineArn",
+            },
+            "",
+          ],
+        },
+      ],
+    },
+  },
+  "Outputs": {
+    "WebsiteBucketArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "capabilityinsightswebsite",
+          "Arn",
+        ],
+      },
+    },
+    "WebsiteBucketName": {
+      "Value": {
+        "Ref": "capabilityinsightswebsite",
+      },
+    },
+  },
   "Parameters": {
+    "AnalysisStateMachineArn": {
+      "Default": "",
+      "Description": "ARN of the Usage Analysis Step Functions state machine. Leave empty if Usage Analysis stack is not yet deployed.",
+      "Type": "String",
+    },
     "ApiAccessSubnetId": {
       "Description": "ID of Subnet where users will browse Capability Insights website from, calls to back-end API will come from here. A VPC Endpoint to API Gateway will be created in this subnet to enable this.",
       "Type": "AWS::EC2::Subnet::Id",
@@ -15,6 +49,21 @@ exports[`CloudFormation template matches snapshot 1`] = `
       "Default": "/cdk-bootstrap/hnb659fds/version",
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "CloudFormationAnalyzerLambdaName": {
+      "Default": "",
+      "Description": "Name of the CloudFormation Analyzer Lambda function.",
+      "Type": "String",
+    },
+    "CloudTrailAnalyzerLambdaName": {
+      "Default": "",
+      "Description": "Name of the CloudTrail Analyzer Lambda function.",
+      "Type": "String",
+    },
+    "ConfiguredCloudTrailBucketName": {
+      "Default": "",
+      "Description": "CloudTrail bucket configured at deploy time. Plumbed to the API Lambda so the UI can trigger analysis without re-supplying the bucket on every request.",
+      "Type": "String",
     },
     "DeploymentAssetsBucketApiLambdaFunctionCodeZipPath": {
       "Default": "lambdaAssets.zip",
@@ -362,6 +411,18 @@ exports[`CloudFormation template matches snapshot 1`] = `
         },
         "Environment": {
           "Variables": {
+            "ANALYSIS_STATE_MACHINE_ARN": {
+              "Ref": "AnalysisStateMachineArn",
+            },
+            "CLOUDFORMATION_ANALYZER_LAMBDA_NAME": {
+              "Ref": "CloudFormationAnalyzerLambdaName",
+            },
+            "CLOUDTRAIL_ANALYZER_LAMBDA_NAME": {
+              "Ref": "CloudTrailAnalyzerLambdaName",
+            },
+            "CONFIGURED_CLOUDTRAIL_BUCKET": {
+              "Ref": "ConfiguredCloudTrailBucketName",
+            },
             "DATA_FETCH_LAMBDA_NAME": "CapabilityInsightsDataFetchLambda",
             "WEBSITE_BUCKET_NAME": {
               "Ref": "capabilityinsightswebsite",
@@ -479,6 +540,108 @@ exports[`CloudFormation template matches snapshot 1`] = `
               "Version": "2012-10-17",
             },
             "PolicyName": "InvokeDataFetchLambda",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:StartExecution",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::If": [
+                      "HasAnalysisStateMachine",
+                      {
+                        "Ref": "AnalysisStateMachineArn",
+                      },
+                      {
+                        "Fn::Sub": "arn:\${AWS::Partition}:states:\${AWS::Region}:\${AWS::AccountId}:stateMachine:none",
+                      },
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "states:DescribeExecution",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::If": [
+                      "HasAnalysisStateMachine",
+                      {
+                        "Fn::Sub": [
+                          "arn:\${AWS::Partition}:states:\${AWS::Region}:\${AWS::AccountId}:execution:\${StateMachineName}:*",
+                          {
+                            "StateMachineName": {
+                              "Fn::Select": [
+                                6,
+                                {
+                                  "Fn::Split": [
+                                    ":",
+                                    {
+                                      "Ref": "AnalysisStateMachineArn",
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                      {
+                        "Fn::Sub": "arn:\${AWS::Partition}:states:\${AWS::Region}:\${AWS::AccountId}:execution:none:*",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "StepFunctionsAccess",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "organizations:ListAccounts",
+                    "organizations:DescribeOrganization",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "OrganizationsReadAccess",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:GetObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "\${BucketArn}/data/json/*",
+                      {
+                        "BucketArn": {
+                          "Fn::GetAtt": [
+                            "capabilityinsightswebsite",
+                            "Arn",
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3WebsiteBucketRead",
           },
         ],
         "RoleName": {
@@ -670,6 +833,35 @@ exports[`CloudFormation template matches snapshot 1`] = `
       },
       "Type": "AWS::EC2::VPCEndpoint",
     },
+    "CapabilityInsightsStepFunctionsVpcEndpoint": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Ref": "CapabilityInsightsApiGwSecurityGroup",
+          },
+        ],
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.\${AWS::Region}.states",
+        },
+        "SubnetIds": [
+          {
+            "Ref": "BackendSubnetId",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsStepFunctionsVpcEndpoint",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "PrivateVpcId",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
     "CapabilityInsightsWriteConfigLambda": {
       "Properties": {
         "Code": {
@@ -733,7 +925,7 @@ def lambda_handler(event, context):
           ],
         },
         "Bucket": {
-          "Fn::Sub": "capability-insights-website-\${AWS::AccountId}-\${AWS::Region}",
+          "Ref": "capabilityinsightswebsite",
         },
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -773,7 +965,17 @@ def lambda_handler(event, context):
                   ],
                   "Effect": "Allow",
                   "Resource": {
-                    "Fn::Sub": "arn:\${AWS::Partition}:s3:::capability-insights-website-\${AWS::AccountId}-\${AWS::Region}/*",
+                    "Fn::Sub": [
+                      "\${BucketArn}/*",
+                      {
+                        "BucketArn": {
+                          "Fn::GetAtt": [
+                            "capabilityinsightswebsite",
+                            "Arn",
+                          ],
+                        },
+                      },
+                    ],
                   },
                 },
               ],

--- a/source/constructs/lib/stacks/__snapshots__/sample-environment-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/sample-environment-stack.test.ts.snap
@@ -132,6 +132,23 @@ exports[`CloudFormation template matches snapshot 1`] = `
       },
       "Type": "AWS::EC2::VPCGatewayAttachment",
     },
+    "CapabilityInsightsSampleEnvironmentVpcPrivateRouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "CapabilityInsightsSampleEnvironmentVpcPrivateRouteTable",
+          },
+        ],
+        "VpcId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpc",
+            "VpcId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
     "CapabilityInsightsSampleEnvironmentVpcPrivateSubnet": {
       "Properties": {
         "AvailabilityZone": {
@@ -158,6 +175,23 @@ exports[`CloudFormation template matches snapshot 1`] = `
         },
       },
       "Type": "AWS::EC2::Subnet",
+    },
+    "CapabilityInsightsSampleEnvironmentVpcPrivateSubnetRouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcPrivateRouteTable",
+            "RouteTableId",
+          ],
+        },
+        "SubnetId": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsSampleEnvironmentVpcPrivateSubnet",
+            "SubnetId",
+          ],
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
     },
     "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable": {
       "Properties": {
@@ -286,6 +320,12 @@ exports[`CloudFormation template matches snapshot 1`] = `
           {
             "Fn::GetAtt": [
               "CapabilityInsightsSampleEnvironmentVpcPublicRouteTable",
+              "RouteTableId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "CapabilityInsightsSampleEnvironmentVpcPrivateRouteTable",
               "RouteTableId",
             ],
           },

--- a/source/constructs/lib/stacks/__snapshots__/usage-analysis-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/usage-analysis-stack.test.ts.snap
@@ -1,0 +1,1069 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CloudFormation template matches snapshot 1`] = `
+{
+  "Conditions": {
+    "CapabilityInsightsHasCloudTrailBucket": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "CloudTrailBucketName",
+            },
+            "",
+          ],
+        },
+      ],
+    },
+  },
+  "Outputs": {
+    "AnalysisStateMachineArn": {
+      "Value": {
+        "Ref": "CapabilityInsightsAnalysisStateMachine",
+      },
+    },
+    "CloudFormationAnalyzerLambdaName": {
+      "Value": "CapabilityInsightsCloudFormationAnalyzer",
+    },
+    "CloudTrailAnalyzerLambdaName": {
+      "Value": "CapabilityInsightsCloudTrailAnalyzer",
+    },
+    "ConfiguredCloudTrailBucketName": {
+      "Value": {
+        "Ref": "CloudTrailBucketName",
+      },
+    },
+    "UsageDecoratorLambdaName": {
+      "Value": "CapabilityInsightsUsageDecorator",
+    },
+  },
+  "Parameters": {
+    "AnalysisSchedule": {
+      "AllowedPattern": "^(rate|cron)\\(.+\\)$",
+      "ConstraintDescription": "Must be a valid EventBridge schedule expression like rate(1 day) or cron(0 6 * * ? *).",
+      "Default": "rate(1 day)",
+      "Description": "EventBridge schedule expression for automated analysis runs (e.g. "rate(1 day)", "cron(0 6 * * ? *)").",
+      "Type": "String",
+    },
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "CloudTrailBucketName": {
+      "Default": "test-trail-bucket",
+      "Description": "Name of the S3 bucket containing CloudTrail logs for usage analysis.",
+      "Type": "String",
+    },
+    "DaysToScan": {
+      "Default": 30,
+      "Description": "CloudTrail lookback window (days) for scheduled analyzer runs.",
+      "MaxValue": 90,
+      "MinValue": 1,
+      "Type": "Number",
+    },
+    "DeployerRoleName": {
+      "Default": "Admin",
+      "Description": "Name of the IAM role used to deploy this stack. Added as a Lake Formation Data Lake Admin so subsequent LF Permissions can be granted. Defaults to "Admin".",
+      "Type": "String",
+    },
+    "DeploymentAssetsBucketName": {
+      "Default": "test-deployment-bucket",
+      "Description": "Name of S3 bucket where deployment assets (Lambda code zip) are located.",
+      "Type": "String",
+    },
+    "LambdaCodeZipPath": {
+      "Default": "lambdaAssets.zip",
+      "Description": "Path in the deployment assets bucket where the Lambda code zip is located.",
+      "Type": "String",
+    },
+    "WebsiteBucketArn": {
+      "Default": "arn:aws:s3:::test-website-bucket",
+      "Description": "ARN of the Capability Insights website S3 bucket.",
+      "Type": "String",
+    },
+    "WebsiteBucketName": {
+      "Default": "test-website-bucket",
+      "Description": "Name of the Capability Insights website S3 bucket (for storing analysis results).",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "CapabilityInsightsAnalysisScheduleRole": {
+      "Condition": "CapabilityInsightsHasCloudTrailBucket",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "ArnLike": {
+                  "aws:SourceArn": {
+                    "Fn::Sub": "arn:\${AWS::Partition}:events:\${AWS::Region}:\${AWS::AccountId}:rule/*",
+                  },
+                },
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:StartExecution",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "CapabilityInsightsAnalysisStateMachine",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "InvokeStateMachine",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsAnalysisScheduleRule": {
+      "Condition": "CapabilityInsightsHasCloudTrailBucket",
+      "Properties": {
+        "Description": "Daily trigger for CapabilityInsightsAnalysisStateMachine.",
+        "ScheduleExpression": {
+          "Ref": "AnalysisSchedule",
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CapabilityInsightsAnalysisStateMachine",
+            },
+            "Id": "AnalysisStateMachineTarget",
+            "Input": {
+              "Fn::Sub": [
+                "{"scope":"account","accounts":["\${AccountId}"],"analyzers":["cloudtrail","cloudformation"],"cloudTrailBucket":"\${CloudTrailBucket}","cloudTrailPrefix":"AWSLogs/","daysToScan":\${DaysToScan},"websiteBucket":"\${WebsiteBucket}","cloudtrailAnalyzerLambda":"\${CloudTrailAnalyzerLambda}","cloudformationAnalyzerLambda":"\${CloudFormationAnalyzerLambda}","resourceExplorerAnalyzerLambda":""}",
+                {
+                  "AccountId": {
+                    "Ref": "AWS::AccountId",
+                  },
+                  "CloudFormationAnalyzerLambda": "CapabilityInsightsCloudFormationAnalyzer",
+                  "CloudTrailAnalyzerLambda": "CapabilityInsightsCloudTrailAnalyzer",
+                  "CloudTrailBucket": {
+                    "Ref": "CloudTrailBucketName",
+                  },
+                  "DaysToScan": {
+                    "Ref": "DaysToScan",
+                  },
+                  "WebsiteBucket": {
+                    "Ref": "WebsiteBucketName",
+                  },
+                },
+              ],
+            },
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CapabilityInsightsAnalysisScheduleRole",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CapabilityInsightsAnalysisStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{"Comment":"Analysis workflow: parallel analyzers → merge usage into personalized files","StartAt":"ParallelAnalyzers","States":{"ParallelAnalyzers":{"Type":"Parallel","ResultPath":"$.parallelResults","Next":"DecorateUsage","Branches":[{"StartAt":"CloudTrailAnalyzer","States":{"CloudTrailAnalyzer":{"Type":"Task","Resource":"",
+              {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsCloudTrailAnalyzer",
+                  "Arn",
+                ],
+              },
+              "","TimeoutSeconds":300,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException","Lambda.TooManyRequestsException"],"IntervalSeconds":2,"MaxAttempts":3,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.ALL"],"Next":"CloudTrailFailed","ResultPath":"$.error"}],"End":true},"CloudTrailFailed":{"Type":"Pass","Parameters":{"analyzer":"cloudtrail","status":"failed","error.$":"$.error"},"End":true}}},{"StartAt":"CloudFormationAnalyzer","States":{"CloudFormationAnalyzer":{"Type":"Task","Resource":"",
+              {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsCloudFormationAnalyzer",
+                  "Arn",
+                ],
+              },
+              "","TimeoutSeconds":300,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException","Lambda.TooManyRequestsException"],"IntervalSeconds":2,"MaxAttempts":3,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.ALL"],"Next":"CloudFormationFailed","ResultPath":"$.error"}],"End":true},"CloudFormationFailed":{"Type":"Pass","Parameters":{"analyzer":"cloudformation","status":"failed","error.$":"$.error"},"End":true}}}]},"DecorateUsage":{"Type":"Task","Resource":"",
+              {
+                "Fn::GetAtt": [
+                  "CapabilityInsightsUsageDecorator",
+                  "Arn",
+                ],
+              },
+              "","TimeoutSeconds":120,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException","Lambda.TooManyRequestsException"],"IntervalSeconds":2,"MaxAttempts":3,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.ALL"],"Next":"DecorateUsageFailed","ResultPath":"$.decorateError"}],"End":true},"DecorateUsageFailed":{"Type":"Pass","Parameters":{"step":"decorate","status":"failed","error.$":"$.decorateError"},"End":true}}}",
+            ],
+          ],
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsAnalysisStateMachineRole297A7C39",
+            "Arn",
+          ],
+        },
+        "StateMachineName": "CapabilityInsightsAnalysisStateMachine",
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+    },
+    "CapabilityInsightsAnalysisStateMachineRole297A7C39": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "states.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "lambda:InvokeFunction",
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "CapabilityInsightsCloudTrailAnalyzer",
+                        "Arn",
+                      ],
+                    },
+                    {
+                      "Fn::GetAtt": [
+                        "CapabilityInsightsCloudFormationAnalyzer",
+                        "Arn",
+                      ],
+                    },
+                    {
+                      "Fn::GetAtt": [
+                        "CapabilityInsightsUsageDecorator",
+                        "Arn",
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "InvokeLambda",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsCloudFormationAnalyzer": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeploymentAssetsBucketName",
+          },
+          "S3Key": {
+            "Ref": "LambdaCodeZipPath",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "WEBSITE_BUCKET_NAME": {
+              "Ref": "WebsiteBucketName",
+            },
+          },
+        },
+        "FunctionName": "CapabilityInsightsCloudFormationAnalyzer",
+        "Handler": "cloudformation-analyzer.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsCloudFormationAnalyzerRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs24.x",
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsCloudFormationAnalyzerRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "cloudformation:ListStacks",
+                    "cloudformation:GetTemplate",
+                    "cloudformation:DescribeStacks",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "CloudFormationRead",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "\${BucketArn}/usage/*",
+                        {
+                          "BucketArn": {
+                            "Ref": "WebsiteBucketArn",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3WriteAccess",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsCloudFormationAnalyzerRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsCloudTrailAnalyzer": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeploymentAssetsBucketName",
+          },
+          "S3Key": {
+            "Ref": "LambdaCodeZipPath",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "WEBSITE_BUCKET_NAME": {
+              "Ref": "WebsiteBucketName",
+            },
+          },
+        },
+        "FunctionName": "CapabilityInsightsCloudTrailAnalyzer",
+        "Handler": "cloudtrail-analyzer.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsCloudTrailAnalyzerRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs24.x",
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsCloudTrailAnalyzerRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "athena:StartQueryExecution",
+                    "athena:GetQueryExecution",
+                    "athena:GetQueryResults",
+                    "athena:StopQueryExecution",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:\${AWS::Partition}:athena:\${AWS::Region}:\${AWS::AccountId}:workgroup/primary",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "AthenaAccess",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "glue:GetDatabase",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:\${AWS::Partition}:glue:\${AWS::Region}:\${AWS::AccountId}:catalog",
+                    },
+                    {
+                      "Fn::Sub": "arn:\${AWS::Partition}:glue:\${AWS::Region}:\${AWS::AccountId}:database/cloudtrail_analysis",
+                    },
+                  ],
+                },
+                {
+                  "Action": [
+                    "glue:GetTable",
+                    "glue:GetTables",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:\${AWS::Partition}:glue:\${AWS::Region}:\${AWS::AccountId}:catalog",
+                    },
+                    {
+                      "Fn::Sub": "arn:\${AWS::Partition}:glue:\${AWS::Region}:\${AWS::AccountId}:database/cloudtrail_analysis",
+                    },
+                    {
+                      "Fn::Sub": "arn:\${AWS::Partition}:glue:\${AWS::Region}:\${AWS::AccountId}:table/cloudtrail_analysis/*",
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "GlueCatalogAccess",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:\${AWS::Partition}:s3:::\${BucketName}",
+                        {
+                          "BucketName": {
+                            "Ref": "CloudTrailBucketName",
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      "Fn::Sub": [
+                        "arn:\${AWS::Partition}:s3:::\${BucketName}/*",
+                        {
+                          "BucketName": {
+                            "Ref": "CloudTrailBucketName",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  "Sid": "ReadCloudTrailLogs",
+                },
+                {
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Ref": "WebsiteBucketArn",
+                    },
+                    {
+                      "Fn::Sub": [
+                        "\${BucketArn}/athena-results/*",
+                        {
+                          "BucketArn": {
+                            "Ref": "WebsiteBucketArn",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  "Sid": "ReadAthenaResults",
+                },
+                {
+                  "Action": [
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "WebsiteBucketArn",
+                  },
+                  "Sid": "GetWebsiteBucketLocation",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3ReadAccess",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "\${BucketArn}/athena-results/*",
+                        {
+                          "BucketArn": {
+                            "Ref": "WebsiteBucketArn",
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      "Fn::Sub": [
+                        "\${BucketArn}/usage/*",
+                        {
+                          "BucketArn": {
+                            "Ref": "WebsiteBucketArn",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3WriteAccess",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsCloudTrailAnalyzerRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsCloudTrailDatabase": {
+      "Properties": {
+        "CatalogId": {
+          "Ref": "AWS::AccountId",
+        },
+        "DatabaseInput": {
+          "Description": "Database for CloudTrail usage analysis queries",
+          "Name": "cloudtrail_analysis",
+        },
+      },
+      "Type": "AWS::Glue::Database",
+    },
+    "CapabilityInsightsCloudTrailTable": {
+      "DependsOn": [
+        "CapabilityInsightsCloudTrailDatabase",
+      ],
+      "Properties": {
+        "CatalogId": {
+          "Ref": "AWS::AccountId",
+        },
+        "DatabaseName": "cloudtrail_analysis",
+        "TableInput": {
+          "Description": "CloudTrail logs table with partition projection",
+          "Name": "cloudtrail_logs",
+          "Parameters": {
+            "projection.enabled": "false",
+          },
+          "PartitionKeys": [],
+          "StorageDescriptor": {
+            "Columns": [
+              {
+                "Name": "eventversion",
+                "Type": "string",
+              },
+              {
+                "Name": "useridentity",
+                "Type": "struct<type:string,principalid:string,arn:string,accountid:string,invokedby:string,accesskeyid:string,username:string,sessioncontext:struct<attributes:struct<mfaauthenticated:string,creationdate:string>,sessionissuer:struct<type:string,principalid:string,arn:string,accountid:string,username:string>>>",
+              },
+              {
+                "Name": "eventtime",
+                "Type": "string",
+              },
+              {
+                "Name": "eventsource",
+                "Type": "string",
+              },
+              {
+                "Name": "eventname",
+                "Type": "string",
+              },
+              {
+                "Name": "awsregion",
+                "Type": "string",
+              },
+              {
+                "Name": "sourceipaddress",
+                "Type": "string",
+              },
+              {
+                "Name": "useragent",
+                "Type": "string",
+              },
+              {
+                "Name": "errorcode",
+                "Type": "string",
+              },
+              {
+                "Name": "errormessage",
+                "Type": "string",
+              },
+              {
+                "Name": "requestparameters",
+                "Type": "string",
+              },
+              {
+                "Name": "responseelements",
+                "Type": "string",
+              },
+              {
+                "Name": "additionaleventdata",
+                "Type": "string",
+              },
+              {
+                "Name": "requestid",
+                "Type": "string",
+              },
+              {
+                "Name": "eventid",
+                "Type": "string",
+              },
+              {
+                "Name": "resources",
+                "Type": "array<struct<arn:string,accountid:string,type:string>>",
+              },
+              {
+                "Name": "eventtype",
+                "Type": "string",
+              },
+              {
+                "Name": "apiversion",
+                "Type": "string",
+              },
+              {
+                "Name": "readonly",
+                "Type": "string",
+              },
+              {
+                "Name": "recipientaccountid",
+                "Type": "string",
+              },
+              {
+                "Name": "serviceeventdetails",
+                "Type": "string",
+              },
+              {
+                "Name": "sharedeventid",
+                "Type": "string",
+              },
+              {
+                "Name": "vpcendpointid",
+                "Type": "string",
+              },
+            ],
+            "InputFormat": "com.amazon.emr.cloudtrail.CloudTrailInputFormat",
+            "Location": {
+              "Fn::Sub": [
+                "s3://\${BucketName}/AWSLogs/\${AWS::AccountId}/CloudTrail/",
+                {
+                  "BucketName": {
+                    "Ref": "CloudTrailBucketName",
+                  },
+                },
+              ],
+            },
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            "SerdeInfo": {
+              "SerializationLibrary": "com.amazon.emr.hive.serde.CloudTrailSerde",
+            },
+          },
+          "TableType": "EXTERNAL_TABLE",
+        },
+      },
+      "Type": "AWS::Glue::Table",
+    },
+    "CapabilityInsightsLakeFormationBootstrap": {
+      "DependsOn": [
+        "CapabilityInsightsCloudTrailAnalyzerRole",
+      ],
+      "Properties": {
+        "AdminsToAdd": [
+          {
+            "Fn::GetAtt": [
+              "CapabilityInsightsCloudTrailAnalyzerRole",
+              "Arn",
+            ],
+          },
+          {
+            "Fn::Sub": [
+              "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/\${DeployerRoleName}",
+              {
+                "DeployerRoleName": {
+                  "Ref": "DeployerRoleName",
+                },
+              },
+            ],
+          },
+        ],
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsLakeFormationBootstrapLambda",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+    },
+    "CapabilityInsightsLakeFormationBootstrapLambda": {
+      "DependsOn": [
+        "CapabilityInsightsLakeFormationBootstrapLambdaRole",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "import boto3
+import cfnresponse
+
+lf = boto3.client('lakeformation')
+
+def lambda_handler(event, context):
+    try:
+        # Don't strip LF admins on stack delete — would orphan any
+        # LF-protected resources still managed by those admins.
+        if event['RequestType'] == 'Delete':
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+            return
+
+        admins_to_add = event['ResourceProperties']['AdminsToAdd']
+        if isinstance(admins_to_add, str):
+            admins_to_add = [admins_to_add]
+
+        existing = lf.get_data_lake_settings()['DataLakeSettings']
+        existing_admins = existing.get('DataLakeAdmins', []) or []
+        existing_arns = {a.get('DataLakePrincipalIdentifier') for a in existing_admins}
+
+        merged = list(existing_admins)
+        for arn in admins_to_add:
+            if arn and arn not in existing_arns:
+                merged.append({'DataLakePrincipalIdentifier': arn})
+                existing_arns.add(arn)
+
+        new_settings = dict(existing)
+        new_settings['DataLakeAdmins'] = merged
+        lf.put_data_lake_settings(DataLakeSettings=new_settings)
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, {'AdminsConfigured': str(len(merged))})
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)})",
+        },
+        "FunctionName": "CapabilityInsightsLakeFormationBootstrapLambda",
+        "Handler": "index.lambda_handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsLakeFormationBootstrapLambdaRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.11",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsLakeFormationBootstrapLambdaRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lakeformation:GetDataLakeSettings",
+                    "lakeformation:PutDataLakeSettings",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "LakeFormationBootstrap",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsLakeFormationBootstrapLambdaRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CapabilityInsightsLakeFormationDbPermission": {
+      "DependsOn": [
+        "CapabilityInsightsCloudTrailAnalyzerRole",
+        "CapabilityInsightsCloudTrailDatabase",
+        "CapabilityInsightsLakeFormationBootstrap",
+      ],
+      "Properties": {
+        "DataLakePrincipal": {
+          "DataLakePrincipalIdentifier": {
+            "Fn::GetAtt": [
+              "CapabilityInsightsCloudTrailAnalyzerRole",
+              "Arn",
+            ],
+          },
+        },
+        "Permissions": [
+          "DESCRIBE",
+        ],
+        "Resource": {
+          "DatabaseResource": {
+            "Name": "cloudtrail_analysis",
+          },
+        },
+      },
+      "Type": "AWS::LakeFormation::Permissions",
+    },
+    "CapabilityInsightsLakeFormationTablePermission": {
+      "DependsOn": [
+        "CapabilityInsightsCloudTrailAnalyzerRole",
+        "CapabilityInsightsCloudTrailTable",
+        "CapabilityInsightsLakeFormationBootstrap",
+      ],
+      "Properties": {
+        "DataLakePrincipal": {
+          "DataLakePrincipalIdentifier": {
+            "Fn::GetAtt": [
+              "CapabilityInsightsCloudTrailAnalyzerRole",
+              "Arn",
+            ],
+          },
+        },
+        "Permissions": [
+          "DESCRIBE",
+          "SELECT",
+        ],
+        "Resource": {
+          "TableResource": {
+            "DatabaseName": "cloudtrail_analysis",
+            "TableWildcard": {},
+          },
+        },
+      },
+      "Type": "AWS::LakeFormation::Permissions",
+    },
+    "CapabilityInsightsUsageDecorator": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeploymentAssetsBucketName",
+          },
+          "S3Key": {
+            "Ref": "LambdaCodeZipPath",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "INCLUDE_ALL_FEATURES_PER_SERVICE": "true",
+            "WEBSITE_BUCKET_NAME": {
+              "Ref": "WebsiteBucketName",
+            },
+          },
+        },
+        "FunctionName": "CapabilityInsightsUsageDecorator",
+        "Handler": "usage-decorator.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "CapabilityInsightsUsageDecoratorRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs24.x",
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CapabilityInsightsUsageDecoratorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:GetObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "\${BucketArn}/data/json/*",
+                      {
+                        "BucketArn": {
+                          "Ref": "WebsiteBucketArn",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3ReadMasterCatalogs",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "\${BucketArn}/data/json/used-*.json",
+                      {
+                        "BucketArn": {
+                          "Ref": "WebsiteBucketArn",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "S3WriteUsedFiles",
+          },
+        ],
+        "RoleName": {
+          "Fn::Sub": "CapabilityInsightsUsageDecoratorRole-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/source/constructs/lib/stacks/capability-insights-stack.test.ts
+++ b/source/constructs/lib/stacks/capability-insights-stack.test.ts
@@ -1,6 +1,6 @@
 import { App } from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
-import { afterAll, expect, test } from 'vitest';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { afterAll, describe, expect, test } from 'vitest';
 import { CapabilityInsightsStack } from './capability-insights-stack';
 
 let snapshotFailed = false;
@@ -14,6 +14,53 @@ test('CloudFormation template matches snapshot', () => {
     snapshotFailed = true;
     throw e;
   }
+});
+
+describe('API Lambda role', () => {
+  const app = new App();
+  const stack = new CapabilityInsightsStack(app, 'TestStack-IAM');
+  const template = Template.fromStack(stack);
+
+  test('has Organizations read access policy', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      Policies: Match.arrayWith([
+        Match.objectLike({
+          PolicyName: 'OrganizationsReadAccess',
+          PolicyDocument: {
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['organizations:ListAccounts', 'organizations:DescribeOrganization'],
+                Resource: '*',
+              },
+            ],
+          },
+        }),
+      ]),
+    });
+  });
+
+  test('has Step Functions access policy with separate statements for state machine and execution ARNs', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      Policies: Match.arrayWith([
+        Match.objectLike({
+          PolicyName: 'StepFunctionsAccess',
+          PolicyDocument: {
+            Statement: [
+              Match.objectLike({
+                Effect: 'Allow',
+                Action: ['states:StartExecution'],
+              }),
+              Match.objectLike({
+                Effect: 'Allow',
+                Action: ['states:DescribeExecution'],
+              }),
+            ],
+          },
+        }),
+      ]),
+    });
+  });
 });
 
 afterAll(() => {

--- a/source/constructs/lib/stacks/capability-insights-stack.ts
+++ b/source/constructs/lib/stacks/capability-insights-stack.ts
@@ -14,8 +14,27 @@ export interface CapabilityInsightsStackProps extends cdk.StackProps {
   deploymentAssetsBucketName?: string;
   sourceAccessPointArn?: string;
   sourceFolders?: string;
+  analysisStateMachineArn?: string;
+  cloudTrailAnalyzerLambdaName?: string;
+  cloudFormationAnalyzerLambdaName?: string;
+  configuredCloudTrailBucketName?: string;
 }
 
+export enum CapabilityInsightsStackOutputs {
+  WebsiteBucketName = 'WebsiteBucketName',
+  WebsiteBucketArn = 'WebsiteBucketArn',
+}
+
+/**
+ * Main Capability Insights application stack.
+ *
+ * Creates the website S3 bucket, private API Gateway, API Lambda, data fetch Lambda,
+ * VPC endpoints, and supporting resources. Accepts optional parameters from the
+ * Usage Analysis stack (AnalysisStateMachineArn, CloudTrailAnalyzerLambdaName)
+ * to enable the personalization features.
+ *
+ * Deployment order: Environment → Insights → Usage Analysis → Update Insights (with analysis params)
+ */
 export class CapabilityInsightsStack extends cdk.Stack {
   constructor(app: cdk.App, id: string, props?: CapabilityInsightsStackProps) {
     super(app, id, props);
@@ -59,6 +78,36 @@ export class CapabilityInsightsStack extends cdk.Stack {
       description: 'ARN of the S3 access point that provides the capability data source.',
       default: props?.sourceAccessPointArn,
     });
+    const analysisStateMachineArnParameter = new cdk.CfnParameter(this, 'AnalysisStateMachineArn', {
+      type: 'String',
+      description:
+        'ARN of the Usage Analysis Step Functions state machine. Leave empty if Usage Analysis stack is not yet deployed.',
+      default: props?.analysisStateMachineArn ?? '',
+    });
+
+    const hasAnalysisStateMachine = new cdk.CfnCondition(this, 'HasAnalysisStateMachine', {
+      expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(analysisStateMachineArnParameter.valueAsString, '')),
+    });
+
+    const cloudTrailAnalyzerLambdaNameParameter = new cdk.CfnParameter(this, 'CloudTrailAnalyzerLambdaName', {
+      type: 'String',
+      description: 'Name of the CloudTrail Analyzer Lambda function.',
+      default: props?.cloudTrailAnalyzerLambdaName ?? '',
+    });
+
+    const cloudformationAnalyzerLambdaNameParameter = new cdk.CfnParameter(this, 'CloudFormationAnalyzerLambdaName', {
+      type: 'String',
+      description: 'Name of the CloudFormation Analyzer Lambda function.',
+      default: props?.cloudFormationAnalyzerLambdaName ?? '',
+    });
+
+    const configuredCloudTrailBucketParameter = new cdk.CfnParameter(this, 'ConfiguredCloudTrailBucketName', {
+      type: 'String',
+      description:
+        'CloudTrail bucket configured at deploy time. Plumbed to the API Lambda so the UI can trigger analysis without re-supplying the bucket on every request.',
+      default: props?.configuredCloudTrailBucketName ?? '',
+    });
+
     const sourceFoldersParameter = new cdk.CfnParameter(this, 'SourceFolders', {
       type: 'String',
       description: 'Comma-separated list of folder names in the S3 access point to fetch data from.',
@@ -71,9 +120,8 @@ export class CapabilityInsightsStack extends cdk.Stack {
     // Website bucket name: "capability-insights-website-{account}-{region}"
     // Also referenced in: deployment/deploy.sh, deployment/dev.sh, README.md
     const websiteBucketResourceName = `capability-insights-website`;
-    const websiteBucketNameFn = cdk.Fn.sub('capability-insights-website-${AWS::AccountId}-${AWS::Region}');
     const websiteBucket = new s3.CfnBucket(this, websiteBucketResourceName, {
-      bucketName: websiteBucketNameFn,
+      bucketName: cdk.Fn.sub('capability-insights-website-${AWS::AccountId}-${AWS::Region}'),
       publicAccessBlockConfiguration: {
         blockPublicAcls: true,
         blockPublicPolicy: true,
@@ -155,6 +203,17 @@ export class CapabilityInsightsStack extends cdk.Stack {
       subnetIds: [privateSubnetIdParameter.valueAsString],
       securityGroupIds: [apigwSecurityGroup.ref],
       tags: [{ key: 'Name', value: `${prefix}LambdaVpcEndpoint` }],
+    });
+
+    // Allows the API Lambda to invoke Step Functions
+    new ec2.CfnVPCEndpoint(this, `${prefix}StepFunctionsVpcEndpoint`, {
+      vpcId: vpcIdParameter.valueAsString,
+      vpcEndpointType: 'Interface',
+      serviceName: cdk.Fn.sub('com.amazonaws.${AWS::Region}.states'),
+      privateDnsEnabled: true,
+      subnetIds: [privateSubnetIdParameter.valueAsString],
+      securityGroupIds: [apigwSecurityGroup.ref],
+      tags: [{ key: 'Name', value: `${prefix}StepFunctionsVpcEndpoint` }],
     });
 
     const apigw = new api.CfnRestApi(this, apigwName, {
@@ -331,6 +390,75 @@ export class CapabilityInsightsStack extends cdk.Stack {
             ],
           },
         },
+        {
+          policyName: 'StepFunctionsAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                // StartExecution operates on the state machine ARN.
+                Effect: 'Allow',
+                Action: ['states:StartExecution'],
+                Resource: cdk.Fn.conditionIf(
+                  hasAnalysisStateMachine.logicalId,
+                  analysisStateMachineArnParameter.valueAsString,
+                  cdk.Fn.sub('arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:none'),
+                ),
+              },
+              {
+                // DescribeExecution operates on the execution ARN, which has
+                // a different format than the state machine ARN
+                // (`arn:...:execution:<state-machine-name>:<execution-id>`).
+                // Authorize any execution under the configured state machine.
+                Effect: 'Allow',
+                Action: ['states:DescribeExecution'],
+                Resource: cdk.Fn.conditionIf(
+                  hasAnalysisStateMachine.logicalId,
+                  cdk.Fn.sub(
+                    'arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${StateMachineName}:*',
+                    {
+                      StateMachineName: cdk.Fn.select(
+                        6,
+                        cdk.Fn.split(':', analysisStateMachineArnParameter.valueAsString),
+                      ),
+                    },
+                  ),
+                  cdk.Fn.sub('arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:none:*'),
+                ),
+              },
+            ],
+          },
+        },
+        {
+          policyName: 'OrganizationsReadAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['organizations:ListAccounts', 'organizations:DescribeOrganization'],
+                Resource: '*',
+              },
+            ],
+          },
+        },
+        {
+          // Reads pre-computed used-capabilities-*.json files written by the
+          // usage decorator Lambda, as well as api-config.json for route metadata.
+          policyName: 'S3WebsiteBucketRead',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['s3:GetObject'],
+                Resource: cdk.Fn.sub('${BucketArn}/data/json/*', {
+                  BucketArn: cdk.Fn.getAtt(websiteBucket.logicalId, 'Arn').toString(),
+                }),
+              },
+            ],
+          },
+        },
       ],
     });
     const apiLambdaFunction = new lambda.CfnFunction(this, apiLambdaName, {
@@ -351,6 +479,10 @@ export class CapabilityInsightsStack extends cdk.Stack {
         variables: {
           WEBSITE_BUCKET_NAME: cdk.Fn.ref(websiteBucket.logicalId),
           DATA_FETCH_LAMBDA_NAME: dataFetchLambdaName,
+          CLOUDTRAIL_ANALYZER_LAMBDA_NAME: cloudTrailAnalyzerLambdaNameParameter.valueAsString,
+          CLOUDFORMATION_ANALYZER_LAMBDA_NAME: cloudformationAnalyzerLambdaNameParameter.valueAsString,
+          ANALYSIS_STATE_MACHINE_ARN: analysisStateMachineArnParameter.valueAsString,
+          CONFIGURED_CLOUDTRAIL_BUCKET: configuredCloudTrailBucketParameter.valueAsString,
         },
       },
     });
@@ -517,9 +649,9 @@ export class CapabilityInsightsStack extends cdk.Stack {
               {
                 Effect: 'Allow',
                 Action: ['s3:PutObject'],
-                Resource: cdk.Fn.sub(
-                  'arn:${AWS::Partition}:s3:::capability-insights-website-${AWS::AccountId}-${AWS::Region}/*',
-                ),
+                Resource: cdk.Fn.sub('${BucketArn}/*', {
+                  BucketArn: cdk.Fn.getAtt(websiteBucket.logicalId, 'Arn').toString(),
+                }),
               },
             ],
           },
@@ -570,12 +702,20 @@ def lambda_handler(event, context):
     const writeConfigCustomResource = new cdk.CfnCustomResource(this, `${prefix}WriteConfigLambdaCustomResource`, {
       serviceToken: cdk.Fn.getAtt(writeConfigLambdaFunction.logicalId, 'Arn').toString(),
     });
-    writeConfigCustomResource.addPropertyOverride('Bucket', websiteBucketNameFn);
+    writeConfigCustomResource.addPropertyOverride('Bucket', cdk.Fn.ref(websiteBucket.logicalId));
     writeConfigCustomResource.addPropertyOverride(
       'ApiUrl',
       cdk.Fn.sub('https://${ApiId}.execute-api.${AWS::Region}.amazonaws.com/prod', {
         ApiId: apigw.attrRestApiId,
       }),
     );
+
+    // Outputs for cross-stack references
+    new cdk.CfnOutput(this, CapabilityInsightsStackOutputs.WebsiteBucketName, {
+      value: cdk.Fn.ref(websiteBucket.logicalId),
+    });
+    new cdk.CfnOutput(this, CapabilityInsightsStackOutputs.WebsiteBucketArn, {
+      value: cdk.Fn.getAtt(websiteBucket.logicalId, 'Arn').toString(),
+    });
   }
 }

--- a/source/constructs/lib/stacks/sample-environment-stack.ts
+++ b/source/constructs/lib/stacks/sample-environment-stack.ts
@@ -45,6 +45,18 @@ export class CapabilityInsightsSampleEnvironmentStack extends cdk.Stack {
       vpcId: this.vpc.attrVpcId,
       tags: [{ key: 'Name', value: privateSubnetName }],
     });
+    // Explicit private route table. Without this, the subnet falls through
+    // to the VPC main route table, which has no S3 gateway endpoint route,
+    // so Lambdas in the private subnet can't reach S3.
+    const privateRouteTableName = `${vpcName}PrivateRouteTable`;
+    const privateRouteTable = new ec2.CfnRouteTable(this, privateRouteTableName, {
+      vpcId: this.vpc.attrVpcId,
+      tags: [{ key: 'Name', value: privateRouteTableName }],
+    });
+    new ec2.CfnSubnetRouteTableAssociation(this, `${privateSubnetName}RouteTableAssociation`, {
+      subnetId: this.privateSubnet.attrSubnetId,
+      routeTableId: privateRouteTable.attrRouteTableId,
+    });
 
     // What makes a subnet "public" is the presence of an Internet Gateway
     const internetGatewayName = `${vpcName}IGW`;
@@ -85,7 +97,7 @@ export class CapabilityInsightsSampleEnvironmentStack extends cdk.Stack {
       vpcId: this.vpc.attrVpcId,
       vpcEndpointType: 'Gateway',
       serviceName: cdk.Fn.sub('com.amazonaws.${AWS::Region}.s3'),
-      routeTableIds: [publicRouteTable.attrRouteTableId],
+      routeTableIds: [publicRouteTable.attrRouteTableId, privateRouteTable.attrRouteTableId],
       policyDocument: {
         Version: '2012-10-17',
         Statement: [

--- a/source/constructs/lib/stacks/usage-analysis-stack.test.ts
+++ b/source/constructs/lib/stacks/usage-analysis-stack.test.ts
@@ -1,0 +1,146 @@
+import { App } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { afterAll, describe, expect, test } from 'vitest';
+import { UsageAnalysisStack } from './usage-analysis-stack';
+
+let snapshotFailed = false;
+
+function makeStack(overrides: Partial<ConstructorParameters<typeof UsageAnalysisStack>[2]> = {}) {
+  const app = new App();
+  return new UsageAnalysisStack(app, 'TestUsageAnalysisStack', {
+    websiteBucketName: 'test-website-bucket',
+    websiteBucketArn: 'arn:aws:s3:::test-website-bucket',
+    deploymentAssetsBucketName: 'test-deployment-bucket',
+    lambdaCodeZipPath: 'lambdaAssets.zip',
+    cloudTrailBucketName: 'test-trail-bucket',
+    ...overrides,
+  });
+}
+
+test('CloudFormation template matches snapshot', () => {
+  const stack = makeStack();
+  try {
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  } catch (e) {
+    snapshotFailed = true;
+    throw e;
+  }
+});
+
+describe('usage decorator Lambda', () => {
+  const stack = makeStack();
+  const template = Template.fromStack(stack);
+
+  test('sets INCLUDE_ALL_FEATURES_PER_SERVICE=true by default', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'CapabilityInsightsUsageDecorator',
+      Environment: {
+        Variables: Match.objectLike({
+          INCLUDE_ALL_FEATURES_PER_SERVICE: 'true',
+        }),
+      },
+    });
+  });
+});
+
+describe('analysis state machine schedule', () => {
+  const stack = makeStack();
+  const template = Template.fromStack(stack);
+
+  test('creates an EventBridge rule that triggers the state machine on the configured schedule', () => {
+    // Conditional rule: only provisioned when a CloudTrail bucket is configured.
+    // The test fixture above passes a non-empty bucket name so the rule is present.
+    // Schedule expression is wired to the AnalysisSchedule CFN parameter so it
+    // can be overridden per deploy without code changes.
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: { Ref: 'AnalysisSchedule' },
+      State: 'ENABLED',
+    });
+  });
+
+  test('exposes AnalysisSchedule parameter with rate(1 day) default', () => {
+    template.hasParameter('AnalysisSchedule', {
+      Type: 'String',
+      Default: 'rate(1 day)',
+    });
+  });
+
+  test('rule targets the analysis state machine with the schedule role', () => {
+    template.hasResource('AWS::Events::Rule', {
+      Properties: Match.objectLike({
+        Targets: Match.arrayWith([
+          Match.objectLike({
+            Id: 'AnalysisStateMachineTarget',
+            // RoleArn must point at the analysis schedule role specifically
+            // (not, say, the lambda exec role). Tightens against a refactor
+            // accidentally re-pointing the target.
+            RoleArn: {
+              'Fn::GetAtt': [Match.stringLikeRegexp('.*AnalysisScheduleRole.*'), 'Arn'],
+            },
+            Input: Match.anyValue(),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  test('schedule role has states:StartExecution on the state machine', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Principal: { Service: 'events.amazonaws.com' },
+          }),
+        ]),
+      }),
+      Policies: Match.arrayWith([
+        Match.objectLike({
+          PolicyName: 'InvokeStateMachine',
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: 'Allow',
+                Action: ['states:StartExecution'],
+              }),
+            ]),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test('schedule role trust policy is scoped to this account and an EventBridge rule', () => {
+    // Locks in the SourceAccount + SourceArn conditions on the events
+    // service-principal trust. Without this assertion, those conditions
+    // could be silently removed in a future refactor and the looser
+    // "events.amazonaws.com can assume this from any account" trust would
+    // pass the other test above.
+    template.hasResourceProperties('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Principal: { Service: 'events.amazonaws.com' },
+            Condition: Match.objectLike({
+              StringEquals: Match.objectLike({
+                'aws:SourceAccount': Match.anyValue(),
+              }),
+              ArnLike: Match.objectLike({
+                'aws:SourceArn': Match.anyValue(),
+              }),
+            }),
+          }),
+        ]),
+      }),
+    });
+  });
+});
+
+afterAll(() => {
+  if (snapshotFailed) {
+    console.error(
+      '\n📸 Snapshot mismatch! If this change is intentional, update with:\n' +
+        '   npm run test:update-snapshot --workspace=source/constructs\n',
+    );
+  }
+});

--- a/source/constructs/lib/stacks/usage-analysis-stack.ts
+++ b/source/constructs/lib/stacks/usage-analysis-stack.ts
@@ -1,0 +1,900 @@
+import * as cdk from 'aws-cdk-lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as glue from 'aws-cdk-lib/aws-glue';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lakeformation from 'aws-cdk-lib/aws-lakeformation';
+
+export interface UsageAnalysisStackProps extends cdk.StackProps {
+  websiteBucketName?: string;
+  websiteBucketArn?: string;
+  deploymentAssetsBucketName?: string;
+  lambdaCodeZipPath?: string;
+  cloudTrailBucketName?: string;
+  /**
+   * Name of the IAM role used to deploy this stack. Added as a Lake Formation
+   * Data Lake Admin during stack creation so that subsequent
+   * `AWS::LakeFormation::Permissions` resources can be created. On a fresh
+   * account no admins are configured by default, which causes those resources
+   * to fail with AccessDeniedException. Defaults to `Admin`.
+   */
+  deployerRoleName?: string;
+  /**
+   * EventBridge schedule expression for automated analysis runs. Accepts the
+   * AWS Schedule Expression syntax: `rate(...)` for fixed intervals (`rate(1 day)`,
+   * `rate(12 hours)`) or `cron(...)` for time-of-day scheduling
+   * (`cron(0 6 * * ? *)` = daily at 06:00 UTC).
+   *
+   * Default is `rate(1 day)`. To change without redeploying CDK, set the
+   * AnalysisSchedule CloudFormation parameter at deploy time.
+   */
+  analysisSchedule?: string;
+  /**
+   * CloudTrail lookback window (days) for scheduled analyzer runs. Default
+   * is 30. Bigger windows catch less-frequent APIs but cost more in Athena
+   * scans; smaller windows are cheaper but miss occasional usage.
+   */
+  daysToScan?: number;
+}
+
+export enum UsageAnalysisStackOutputs {
+  CloudTrailAnalyzerLambdaName = 'CloudTrailAnalyzerLambdaName',
+  CloudFormationAnalyzerLambdaName = 'CloudFormationAnalyzerLambdaName',
+  UsageDecoratorLambdaName = 'UsageDecoratorLambdaName',
+  AnalysisStateMachineArn = 'AnalysisStateMachineArn',
+  ConfiguredCloudTrailBucketName = 'ConfiguredCloudTrailBucketName',
+}
+
+/**
+ * Usage Analysis CDK stack for the personalization feature.
+ *
+ * Contains the CloudTrail Analyzer Lambda, Step Functions state machine,
+ * and associated IAM roles. Deployed after the insights stack and consumes
+ * the website bucket outputs for storing analysis results.
+ *
+ * Deployment order: Environment → Insights → Usage Analysis
+ */
+export class UsageAnalysisStack extends cdk.Stack {
+  constructor(app: cdk.App, id: string, props?: UsageAnalysisStackProps) {
+    super(app, id, props);
+
+    const prefix = 'CapabilityInsights';
+
+    const websiteBucketNameParameter = new cdk.CfnParameter(this, 'WebsiteBucketName', {
+      type: 'String',
+      description: 'Name of the Capability Insights website S3 bucket (for storing analysis results).',
+      default: props?.websiteBucketName,
+    });
+
+    const websiteBucketArnParameter = new cdk.CfnParameter(this, 'WebsiteBucketArn', {
+      type: 'String',
+      description: 'ARN of the Capability Insights website S3 bucket.',
+      default: props?.websiteBucketArn,
+    });
+
+    const deploymentAssetsBucketNameParameter = new cdk.CfnParameter(this, 'DeploymentAssetsBucketName', {
+      type: 'String',
+      description: 'Name of S3 bucket where deployment assets (Lambda code zip) are located.',
+      default: props?.deploymentAssetsBucketName,
+    });
+
+    const lambdaCodeZipPathParameter = new cdk.CfnParameter(this, 'LambdaCodeZipPath', {
+      type: 'String',
+      description: 'Path in the deployment assets bucket where the Lambda code zip is located.',
+      default: props?.lambdaCodeZipPath ?? 'lambdaAssets.zip',
+    });
+
+    const cloudTrailBucketNameParameter = new cdk.CfnParameter(this, 'CloudTrailBucketName', {
+      type: 'String',
+      description: 'Name of the S3 bucket containing CloudTrail logs for usage analysis.',
+      default: props?.cloudTrailBucketName ?? '',
+    });
+
+    const deployerRoleNameParameter = new cdk.CfnParameter(this, 'DeployerRoleName', {
+      type: 'String',
+      description:
+        'Name of the IAM role used to deploy this stack. Added as a Lake Formation Data Lake Admin so subsequent LF Permissions can be granted. Defaults to "Admin".',
+      default: props?.deployerRoleName ?? 'Admin',
+    });
+
+    const analysisScheduleParameter = new cdk.CfnParameter(this, 'AnalysisSchedule', {
+      type: 'String',
+      description:
+        'EventBridge schedule expression for automated analysis runs (e.g. "rate(1 day)", "cron(0 6 * * ? *)").',
+      default: props?.analysisSchedule ?? 'rate(1 day)',
+      // Reject empty / clearly-malformed values at deploy time.
+      allowedPattern: '^(rate|cron)\\(.+\\)$',
+      constraintDescription: 'Must be a valid EventBridge schedule expression like rate(1 day) or cron(0 6 * * ? *).',
+    });
+
+    const daysToScanParameter = new cdk.CfnParameter(this, 'DaysToScan', {
+      type: 'Number',
+      description: 'CloudTrail lookback window (days) for scheduled analyzer runs.',
+      default: props?.daysToScan ?? 30,
+      minValue: 1,
+      maxValue: 90,
+    });
+
+    // Glue Database and Table for CloudTrail analysis (pre-provisioned at deploy time)
+    const glueDatabase = new glue.CfnDatabase(this, `${prefix}CloudTrailDatabase`, {
+      catalogId: cdk.Fn.ref('AWS::AccountId'),
+      databaseInput: {
+        name: 'cloudtrail_analysis',
+        description: 'Database for CloudTrail usage analysis queries',
+      },
+    });
+
+    const glueTable = new glue.CfnTable(this, `${prefix}CloudTrailTable`, {
+      catalogId: cdk.Fn.ref('AWS::AccountId'),
+      databaseName: 'cloudtrail_analysis',
+      tableInput: {
+        name: 'cloudtrail_logs',
+        description: 'CloudTrail logs table with partition projection',
+        tableType: 'EXTERNAL_TABLE',
+        parameters: {
+          'projection.enabled': 'false',
+        },
+        storageDescriptor: {
+          location: cdk.Fn.sub('s3://${BucketName}/AWSLogs/${AWS::AccountId}/CloudTrail/', {
+            BucketName: cloudTrailBucketNameParameter.valueAsString,
+          }),
+          inputFormat: 'com.amazon.emr.cloudtrail.CloudTrailInputFormat',
+          outputFormat: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+          serdeInfo: {
+            serializationLibrary: 'com.amazon.emr.hive.serde.CloudTrailSerde',
+          },
+          columns: [
+            { name: 'eventversion', type: 'string' },
+            {
+              name: 'useridentity',
+              type: 'struct<type:string,principalid:string,arn:string,accountid:string,invokedby:string,accesskeyid:string,username:string,sessioncontext:struct<attributes:struct<mfaauthenticated:string,creationdate:string>,sessionissuer:struct<type:string,principalid:string,arn:string,accountid:string,username:string>>>',
+            },
+            { name: 'eventtime', type: 'string' },
+            { name: 'eventsource', type: 'string' },
+            { name: 'eventname', type: 'string' },
+            { name: 'awsregion', type: 'string' },
+            { name: 'sourceipaddress', type: 'string' },
+            { name: 'useragent', type: 'string' },
+            { name: 'errorcode', type: 'string' },
+            { name: 'errormessage', type: 'string' },
+            { name: 'requestparameters', type: 'string' },
+            { name: 'responseelements', type: 'string' },
+            { name: 'additionaleventdata', type: 'string' },
+            { name: 'requestid', type: 'string' },
+            { name: 'eventid', type: 'string' },
+            { name: 'resources', type: 'array<struct<arn:string,accountid:string,type:string>>' },
+            { name: 'eventtype', type: 'string' },
+            { name: 'apiversion', type: 'string' },
+            { name: 'readonly', type: 'string' },
+            { name: 'recipientaccountid', type: 'string' },
+            { name: 'serviceeventdetails', type: 'string' },
+            { name: 'sharedeventid', type: 'string' },
+            { name: 'vpcendpointid', type: 'string' },
+          ],
+        },
+        partitionKeys: [],
+      },
+    });
+    glueTable.addDependency(glueDatabase);
+
+    // CloudTrail Analyzer Lambda
+    const cloudtrailAnalyzerLambdaName = `${prefix}CloudTrailAnalyzer`;
+    const cloudtrailAnalyzerRole = new iam.CfnRole(this, `${cloudtrailAnalyzerLambdaName}Role`, {
+      roleName: cdk.Fn.sub(`${cloudtrailAnalyzerLambdaName}Role-\${AWS::Region}`),
+      assumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { Service: 'lambda.amazonaws.com' },
+            Action: 'sts:AssumeRole',
+          },
+        ],
+      },
+      managedPolicyArns: [cdk.Fn.sub('arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole')],
+      policies: [
+        {
+          policyName: 'AthenaAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: [
+                  'athena:StartQueryExecution',
+                  'athena:GetQueryExecution',
+                  'athena:GetQueryResults',
+                  'athena:StopQueryExecution',
+                ],
+                Resource: cdk.Fn.sub('arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary'),
+              },
+            ],
+          },
+        },
+        {
+          policyName: 'GlueCatalogAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['glue:GetDatabase'],
+                Resource: [
+                  cdk.Fn.sub('arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog'),
+                  cdk.Fn.sub(
+                    'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/cloudtrail_analysis',
+                  ),
+                ],
+              },
+              {
+                Effect: 'Allow',
+                Action: ['glue:GetTable', 'glue:GetTables'],
+                Resource: [
+                  cdk.Fn.sub('arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog'),
+                  cdk.Fn.sub(
+                    'arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/cloudtrail_analysis',
+                  ),
+                  cdk.Fn.sub('arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/cloudtrail_analysis/*'),
+                ],
+              },
+            ],
+          },
+        },
+        {
+          policyName: 'S3ReadAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Sid: 'ReadCloudTrailLogs',
+                Effect: 'Allow',
+                Action: ['s3:GetObject', 's3:ListBucket'],
+                Resource: [
+                  cdk.Fn.sub('arn:${AWS::Partition}:s3:::${BucketName}', {
+                    BucketName: cloudTrailBucketNameParameter.valueAsString,
+                  }),
+                  cdk.Fn.sub('arn:${AWS::Partition}:s3:::${BucketName}/*', {
+                    BucketName: cloudTrailBucketNameParameter.valueAsString,
+                  }),
+                ],
+              },
+              {
+                Sid: 'ReadAthenaResults',
+                Effect: 'Allow',
+                Action: ['s3:GetObject', 's3:ListBucket'],
+                Resource: [
+                  websiteBucketArnParameter.valueAsString,
+                  cdk.Fn.sub('${BucketArn}/athena-results/*', {
+                    BucketArn: websiteBucketArnParameter.valueAsString,
+                  }),
+                ],
+              },
+              {
+                Sid: 'GetWebsiteBucketLocation',
+                Effect: 'Allow',
+                Action: ['s3:GetBucketLocation'],
+                Resource: websiteBucketArnParameter.valueAsString,
+              },
+            ],
+          },
+        },
+        {
+          policyName: 'S3WriteAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['s3:PutObject'],
+                Resource: [
+                  cdk.Fn.sub('${BucketArn}/athena-results/*', {
+                    BucketArn: websiteBucketArnParameter.valueAsString,
+                  }),
+                  cdk.Fn.sub('${BucketArn}/usage/*', {
+                    BucketArn: websiteBucketArnParameter.valueAsString,
+                  }),
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    // Bootstrap Lake Formation Data Lake Admins. Adding LF Permissions resources
+    // (below) requires the deployer principal to be a Data Lake Admin. On a fresh
+    // account, no admins are configured, so AWS::LakeFormation::Permissions creation
+    // fails with AccessDeniedException. This custom resource appends the analyzer
+    // role and the deployer role to the existing admin list so the stack can
+    // self-bootstrap LF without clobbering pre-existing admins.
+    //
+    // Implemented as a hand-rolled L1 (lambda.CfnFunction with inline zipFile
+    // + cdk.CfnCustomResource) rather than cr.AwsCustomResource because the
+    // L2 construct ships its provider Lambda code via CDK assets, which this
+    // codebase's deploy.sh flow does not upload (it uses `aws cloudformation
+    // deploy` directly, not `cdk deploy`).
+    const lakeFormationBootstrapLambdaName = `${prefix}LakeFormationBootstrapLambda`;
+    const lakeFormationBootstrapRoleName = `${prefix}LakeFormationBootstrapLambdaRole`;
+    const lakeFormationBootstrapRoleNameFn = cdk.Fn.sub(`${lakeFormationBootstrapRoleName}-\${AWS::Region}`);
+    const lakeFormationBootstrapRole = new iam.CfnRole(this, lakeFormationBootstrapRoleName, {
+      roleName: lakeFormationBootstrapRoleNameFn,
+      assumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { Service: 'lambda.amazonaws.com' },
+            Action: 'sts:AssumeRole',
+          },
+        ],
+      },
+      managedPolicyArns: [cdk.Fn.sub('arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole')],
+      policies: [
+        {
+          policyName: 'LakeFormationBootstrap',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['lakeformation:GetDataLakeSettings', 'lakeformation:PutDataLakeSettings'],
+                Resource: '*',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const lakeFormationBootstrapLambda = new lambda.CfnFunction(this, lakeFormationBootstrapLambdaName, {
+      functionName: lakeFormationBootstrapLambdaName,
+      runtime: 'python3.11',
+      handler: 'index.lambda_handler',
+      role: cdk.Fn.getAtt(lakeFormationBootstrapRole.logicalId, 'Arn').toString(),
+      code: {
+        zipFile: `import boto3
+import cfnresponse
+
+lf = boto3.client('lakeformation')
+
+def lambda_handler(event, context):
+    try:
+        # Don't strip LF admins on stack delete — would orphan any
+        # LF-protected resources still managed by those admins.
+        if event['RequestType'] == 'Delete':
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+            return
+
+        admins_to_add = event['ResourceProperties']['AdminsToAdd']
+        if isinstance(admins_to_add, str):
+            admins_to_add = [admins_to_add]
+
+        existing = lf.get_data_lake_settings()['DataLakeSettings']
+        existing_admins = existing.get('DataLakeAdmins', []) or []
+        existing_arns = {a.get('DataLakePrincipalIdentifier') for a in existing_admins}
+
+        merged = list(existing_admins)
+        for arn in admins_to_add:
+            if arn and arn not in existing_arns:
+                merged.append({'DataLakePrincipalIdentifier': arn})
+                existing_arns.add(arn)
+
+        new_settings = dict(existing)
+        new_settings['DataLakeAdmins'] = merged
+        lf.put_data_lake_settings(DataLakeSettings=new_settings)
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, {'AdminsConfigured': str(len(merged))})
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)})`,
+      },
+      timeout: 60,
+    });
+    lakeFormationBootstrapLambda.addDependency(lakeFormationBootstrapRole);
+
+    const lakeFormationBootstrap = new cdk.CfnCustomResource(this, `${prefix}LakeFormationBootstrap`, {
+      serviceToken: cdk.Fn.getAtt(lakeFormationBootstrapLambda.logicalId, 'Arn').toString(),
+    });
+    lakeFormationBootstrap.addPropertyOverride('AdminsToAdd', [
+      cdk.Fn.getAtt(cloudtrailAnalyzerRole.logicalId, 'Arn').toString(),
+      cdk.Fn.sub('arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${DeployerRoleName}', {
+        DeployerRoleName: deployerRoleNameParameter.valueAsString,
+      }),
+    ]);
+    lakeFormationBootstrap.addDependency(cloudtrailAnalyzerRole);
+
+    // Lake Formation permissions for the Lambda role to access the Glue database and table
+    const lakeFormationDbPermission = new lakeformation.CfnPermissions(this, `${prefix}LakeFormationDbPermission`, {
+      dataLakePrincipal: {
+        dataLakePrincipalIdentifier: cdk.Fn.getAtt(cloudtrailAnalyzerRole.logicalId, 'Arn').toString(),
+      },
+      resource: {
+        databaseResource: {
+          name: 'cloudtrail_analysis',
+        },
+      },
+      permissions: ['DESCRIBE'],
+    });
+    lakeFormationDbPermission.addDependency(glueDatabase);
+    lakeFormationDbPermission.addDependency(cloudtrailAnalyzerRole);
+    lakeFormationDbPermission.node.addDependency(lakeFormationBootstrap);
+
+    const lakeFormationTablePermission = new lakeformation.CfnPermissions(
+      this,
+      `${prefix}LakeFormationTablePermission`,
+      {
+        dataLakePrincipal: {
+          dataLakePrincipalIdentifier: cdk.Fn.getAtt(cloudtrailAnalyzerRole.logicalId, 'Arn').toString(),
+        },
+        resource: {
+          tableResource: {
+            databaseName: 'cloudtrail_analysis',
+            tableWildcard: {},
+          },
+        },
+        permissions: ['DESCRIBE', 'SELECT'],
+      },
+    );
+    lakeFormationTablePermission.addDependency(glueTable);
+    lakeFormationTablePermission.addDependency(cloudtrailAnalyzerRole);
+    lakeFormationTablePermission.node.addDependency(lakeFormationBootstrap);
+
+    const cloudtrailAnalyzerLambda = new lambda.CfnFunction(this, cloudtrailAnalyzerLambdaName, {
+      functionName: cloudtrailAnalyzerLambdaName,
+      runtime: 'nodejs24.x',
+      handler: 'cloudtrail-analyzer.handler',
+      role: cdk.Fn.getAtt(cloudtrailAnalyzerRole.logicalId, 'Arn').toString(),
+      code: {
+        s3Bucket: deploymentAssetsBucketNameParameter.valueAsString,
+        s3Key: lambdaCodeZipPathParameter.valueAsString,
+      },
+      timeout: 300,
+      environment: {
+        variables: {
+          WEBSITE_BUCKET_NAME: websiteBucketNameParameter.valueAsString,
+        },
+      },
+      memorySize: 512,
+    });
+
+    // CloudFormation Analyzer Lambda
+    //
+    // Security note: this Lambda reads every active CloudFormation stack's
+    // processed template in the account via cloudformation:GetTemplate. Templates
+    // may contain sensitive configuration (resource ARNs, VPC/subnet IDs, KMS
+    // key references, etc.). The analyzer only extracts scalar property values
+    // (strings, numbers, booleans) and resource types; nested objects and arrays
+    // are ignored. Output is written to the website bucket's usage/ prefix,
+    // which is only accessible from within the configured VPC.
+    const cloudformationAnalyzerLambdaName = `${prefix}CloudFormationAnalyzer`;
+    const cloudformationAnalyzerRole = new iam.CfnRole(this, `${cloudformationAnalyzerLambdaName}Role`, {
+      roleName: cdk.Fn.sub(`${cloudformationAnalyzerLambdaName}Role-\${AWS::Region}`),
+      assumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { Service: 'lambda.amazonaws.com' },
+            Action: 'sts:AssumeRole',
+          },
+        ],
+      },
+      managedPolicyArns: [cdk.Fn.sub('arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole')],
+      policies: [
+        {
+          policyName: 'CloudFormationRead',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['cloudformation:ListStacks', 'cloudformation:GetTemplate', 'cloudformation:DescribeStacks'],
+                // Resource '*' is required: ListStacks does not support resource-level
+                // permissions, and we need to scan all stacks in the account.
+                Resource: '*',
+              },
+            ],
+          },
+        },
+        {
+          policyName: 'S3WriteAccess',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['s3:PutObject'],
+                Resource: [
+                  cdk.Fn.sub('${BucketArn}/usage/*', {
+                    BucketArn: websiteBucketArnParameter.valueAsString,
+                  }),
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const cloudformationAnalyzerLambda = new lambda.CfnFunction(this, cloudformationAnalyzerLambdaName, {
+      functionName: cloudformationAnalyzerLambdaName,
+      runtime: 'nodejs24.x',
+      handler: 'cloudformation-analyzer.handler',
+      role: cdk.Fn.getAtt(cloudformationAnalyzerRole.logicalId, 'Arn').toString(),
+      code: {
+        s3Bucket: deploymentAssetsBucketNameParameter.valueAsString,
+        s3Key: lambdaCodeZipPathParameter.valueAsString,
+      },
+      timeout: 300,
+      environment: {
+        variables: {
+          WEBSITE_BUCKET_NAME: websiteBucketNameParameter.valueAsString,
+        },
+      },
+      memorySize: 512,
+    });
+
+    // Usage Decorator Lambda
+    //
+    // Runs after the parallel analyzers. Reads the master capability catalogs
+    // (products.json, apis.json, cfn_resources.json) from the website bucket,
+    // decorates the usage data with regional availability, and writes three
+    // personalized files (used-capabilities-{scope}-{filterMode}.json) back
+    // to the same bucket for the UI to consume.
+    const usageDecoratorLambdaName = `${prefix}UsageDecorator`;
+    const usageDecoratorRole = new iam.CfnRole(this, `${usageDecoratorLambdaName}Role`, {
+      roleName: cdk.Fn.sub(`${usageDecoratorLambdaName}Role-\${AWS::Region}`),
+      assumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { Service: 'lambda.amazonaws.com' },
+            Action: 'sts:AssumeRole',
+          },
+        ],
+      },
+      managedPolicyArns: [cdk.Fn.sub('arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole')],
+      policies: [
+        {
+          policyName: 'S3ReadMasterCatalogs',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['s3:GetObject'],
+                Resource: cdk.Fn.sub('${BucketArn}/data/json/*', {
+                  BucketArn: websiteBucketArnParameter.valueAsString,
+                }),
+              },
+            ],
+          },
+        },
+        {
+          policyName: 'S3WriteUsedFiles',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['s3:PutObject'],
+                Resource: cdk.Fn.sub('${BucketArn}/data/json/used-*.json', {
+                  BucketArn: websiteBucketArnParameter.valueAsString,
+                }),
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const usageDecoratorLambda = new lambda.CfnFunction(this, usageDecoratorLambdaName, {
+      functionName: usageDecoratorLambdaName,
+      runtime: 'nodejs24.x',
+      handler: 'usage-decorator.handler',
+      role: cdk.Fn.getAtt(usageDecoratorRole.logicalId, 'Arn').toString(),
+      code: {
+        s3Bucket: deploymentAssetsBucketNameParameter.valueAsString,
+        s3Key: lambdaCodeZipPathParameter.valueAsString,
+      },
+      timeout: 120,
+      environment: {
+        variables: {
+          WEBSITE_BUCKET_NAME: websiteBucketNameParameter.valueAsString,
+          // Keep all features under each kept service in the personalized view.
+          // Set to "false" via stack override to narrow features to only those
+          // directly observed in usage data.
+          INCLUDE_ALL_FEATURES_PER_SERVICE: 'true',
+        },
+      },
+      memorySize: 512,
+    });
+
+    // Step Functions State Machine for Analysis
+    const stateMachineRole = new iam.Role(this, `${prefix}AnalysisStateMachineRole`, {
+      assumedBy: new iam.ServicePrincipal('states.amazonaws.com'),
+      inlinePolicies: {
+        InvokeLambda: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: ['lambda:InvokeFunction'],
+              resources: [
+                cdk.Fn.getAtt(cloudtrailAnalyzerLambda.logicalId, 'Arn').toString(),
+                cdk.Fn.getAtt(cloudformationAnalyzerLambda.logicalId, 'Arn').toString(),
+                cdk.Fn.getAtt(usageDecoratorLambda.logicalId, 'Arn').toString(),
+              ],
+            }),
+          ],
+        }),
+      },
+    });
+
+    // Step Functions State Machine definition
+    //
+    // Error handling strategy:
+    // - Retry: each analyzer task retries up to 3 times on transient Lambda
+    //   errors (throttling, service exceptions) with exponential backoff.
+    // - Catch: if a task still fails, the error is captured in the branch
+    //   output as { analyzer, status: 'failed', error } rather than failing
+    //   the entire parallel execution. Other analyzers continue to run.
+    //
+    // Failures are observable via:
+    // - Lambda CloudWatch Logs (structured logs from the logger utility)
+    // - Step Functions execution history (full retry attempts and error details)
+    // - The /analysis GET endpoint response (returns the captured error)
+    //
+    // Proactive alerting (CloudWatch alarms, SNS notifications) is intentionally
+    // not included here — it's a deployment concern that should be configured
+    // per environment based on the consumer's operational requirements.
+    const stateMachineDefinition = {
+      Comment: 'Analysis workflow: parallel analyzers → merge usage into personalized files',
+      StartAt: 'ParallelAnalyzers',
+      States: {
+        ParallelAnalyzers: {
+          Type: 'Parallel',
+          // Preserve the original input so DecorateUsage still has websiteBucket, etc.
+          // Branch outputs are collected under $.parallelResults.
+          ResultPath: '$.parallelResults',
+          Next: 'DecorateUsage',
+          Branches: [
+            {
+              StartAt: 'CloudTrailAnalyzer',
+              States: {
+                CloudTrailAnalyzer: {
+                  Type: 'Task',
+                  Resource: cdk.Fn.getAtt(cloudtrailAnalyzerLambda.logicalId, 'Arn').toString(),
+                  // Match Lambda timeout so Step Functions fails fast if the
+                  // task hangs. Kept in sync with the Lambda's timeout property.
+                  TimeoutSeconds: cloudtrailAnalyzerLambda.timeout,
+                  Retry: [
+                    {
+                      ErrorEquals: [
+                        'Lambda.ServiceException',
+                        'Lambda.AWSLambdaException',
+                        'Lambda.SdkClientException',
+                        'Lambda.TooManyRequestsException',
+                      ],
+                      IntervalSeconds: 2,
+                      MaxAttempts: 3,
+                      BackoffRate: 2,
+                    },
+                  ],
+                  Catch: [
+                    {
+                      ErrorEquals: ['States.ALL'],
+                      Next: 'CloudTrailFailed',
+                      ResultPath: '$.error',
+                    },
+                  ],
+                  End: true,
+                },
+                CloudTrailFailed: {
+                  Type: 'Pass',
+                  Parameters: { analyzer: 'cloudtrail', status: 'failed', 'error.$': '$.error' },
+                  End: true,
+                },
+              },
+            },
+            {
+              StartAt: 'CloudFormationAnalyzer',
+              States: {
+                CloudFormationAnalyzer: {
+                  Type: 'Task',
+                  Resource: cdk.Fn.getAtt(cloudformationAnalyzerLambda.logicalId, 'Arn').toString(),
+                  // Match Lambda timeout so Step Functions fails fast if the
+                  // task hangs. Kept in sync with the Lambda's timeout property.
+                  TimeoutSeconds: cloudformationAnalyzerLambda.timeout,
+                  Retry: [
+                    {
+                      ErrorEquals: [
+                        'Lambda.ServiceException',
+                        'Lambda.AWSLambdaException',
+                        'Lambda.SdkClientException',
+                        'Lambda.TooManyRequestsException',
+                      ],
+                      IntervalSeconds: 2,
+                      MaxAttempts: 3,
+                      BackoffRate: 2,
+                    },
+                  ],
+                  Catch: [
+                    {
+                      ErrorEquals: ['States.ALL'],
+                      Next: 'CloudFormationFailed',
+                      ResultPath: '$.error',
+                    },
+                  ],
+                  End: true,
+                },
+                CloudFormationFailed: {
+                  Type: 'Pass',
+                  Parameters: { analyzer: 'cloudformation', status: 'failed', 'error.$': '$.error' },
+                  End: true,
+                },
+              },
+            },
+          ],
+        },
+        // Takes the parallel analyzer outputs plus the original input and
+        // writes personalized used-capabilities-{scope}-{filterMode}.json
+        // files to the website bucket, decorated with regional availability.
+        DecorateUsage: {
+          Type: 'Task',
+          Resource: cdk.Fn.getAtt(usageDecoratorLambda.logicalId, 'Arn').toString(),
+          TimeoutSeconds: usageDecoratorLambda.timeout,
+          Retry: [
+            {
+              ErrorEquals: [
+                'Lambda.ServiceException',
+                'Lambda.AWSLambdaException',
+                'Lambda.SdkClientException',
+                'Lambda.TooManyRequestsException',
+              ],
+              IntervalSeconds: 2,
+              MaxAttempts: 3,
+              BackoffRate: 2,
+            },
+          ],
+          Catch: [
+            {
+              ErrorEquals: ['States.ALL'],
+              Next: 'DecorateUsageFailed',
+              ResultPath: '$.decorateError',
+            },
+          ],
+          End: true,
+        },
+        DecorateUsageFailed: {
+          Type: 'Pass',
+          Parameters: { step: 'decorate', status: 'failed', 'error.$': '$.decorateError' },
+          End: true,
+        },
+      },
+    };
+
+    const stateMachine = new cdk.aws_stepfunctions.CfnStateMachine(this, `${prefix}AnalysisStateMachine`, {
+      stateMachineName: `${prefix}AnalysisStateMachine`,
+      roleArn: stateMachineRole.roleArn,
+      definitionString: JSON.stringify(stateMachineDefinition),
+    });
+
+    // Scheduled rule to trigger the analysis state machine daily.
+    //
+    // Ensures account owners get refreshed personalized data without needing
+    // to call POST /analysis manually. Mirrors the existing DataFetch schedule
+    // pattern in the insights stack. Only wires a rule when a CloudTrail bucket
+    // is configured, since cloudtrail is a required analyzer; if the bucket is
+    // absent, scheduled runs would just fail at the analyzer step.
+    const hasCloudTrailBucket = new cdk.CfnCondition(this, `${prefix}HasCloudTrailBucket`, {
+      expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(cloudTrailBucketNameParameter.valueAsString, '')),
+    });
+
+    // Dedicated role so the rule can call states:StartExecution.
+    //
+    // Trust is scoped to EventBridge in *this* account only (SourceAccount),
+    // and to a rule under this stack's events namespace (SourceArn). The
+    // wildcard on the rule name avoids a circular CFN reference between the
+    // role and rule; it's tight enough because (a) SourceAccount restricts
+    // the assumer to our own account and (b) the role's policy below only
+    // permits starting *this* state machine.
+    const analysisScheduleRole = new iam.CfnRole(this, `${prefix}AnalysisScheduleRole`, {
+      assumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { Service: 'events.amazonaws.com' },
+            Action: 'sts:AssumeRole',
+            Condition: {
+              StringEquals: { 'aws:SourceAccount': cdk.Aws.ACCOUNT_ID },
+              ArnLike: {
+                'aws:SourceArn': cdk.Fn.sub('arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*'),
+              },
+            },
+          },
+        ],
+      },
+      policies: [
+        {
+          policyName: 'InvokeStateMachine',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: ['states:StartExecution'],
+                Resource: cdk.Fn.ref(stateMachine.logicalId),
+              },
+            ],
+          },
+        },
+      ],
+    });
+    analysisScheduleRole.cfnOptions.condition = hasCloudTrailBucket;
+
+    // Mirrors the POST /analysis input shape.
+    const baseInput = JSON.stringify({
+      scope: 'account',
+      accounts: ['__ACCOUNTS__'],
+      analyzers: ['cloudtrail', 'cloudformation'],
+      cloudTrailBucket: '__BUCKET__',
+      cloudTrailPrefix: 'AWSLogs/',
+      daysToScan: '__DAYS__',
+      websiteBucket: '__WEBSITE__',
+      cloudtrailAnalyzerLambda: '__CT_LAMBDA__',
+      cloudformationAnalyzerLambda: '__CF_LAMBDA__',
+      resourceExplorerAnalyzerLambda: '',
+    });
+    const scheduledAnalysisInputTemplate = baseInput
+      .replace('"__ACCOUNTS__"', '"${AccountId}"')
+      .replace('"__BUCKET__"', '"${CloudTrailBucket}"')
+      // Unquoted on both sides so the substituted value is a JSON number.
+      .replace('"__DAYS__"', '${DaysToScan}')
+      .replace('"__WEBSITE__"', '"${WebsiteBucket}"')
+      .replace('"__CT_LAMBDA__"', '"${CloudTrailAnalyzerLambda}"')
+      .replace('"__CF_LAMBDA__"', '"${CloudFormationAnalyzerLambda}"');
+
+    const analysisScheduleRule = new events.CfnRule(this, `${prefix}AnalysisScheduleRule`, {
+      description: `Daily trigger for ${prefix}AnalysisStateMachine.`,
+      scheduleExpression: analysisScheduleParameter.valueAsString,
+      state: 'ENABLED',
+      targets: [
+        {
+          arn: cdk.Fn.ref(stateMachine.logicalId),
+          id: 'AnalysisStateMachineTarget',
+          roleArn: cdk.Fn.getAtt(analysisScheduleRole.logicalId, 'Arn').toString(),
+          input: cdk.Fn.sub(scheduledAnalysisInputTemplate, {
+            AccountId: cdk.Aws.ACCOUNT_ID,
+            CloudTrailBucket: cloudTrailBucketNameParameter.valueAsString,
+            DaysToScan: daysToScanParameter.valueAsString,
+            WebsiteBucket: websiteBucketNameParameter.valueAsString,
+            CloudTrailAnalyzerLambda: cloudtrailAnalyzerLambdaName,
+            CloudFormationAnalyzerLambda: cloudformationAnalyzerLambdaName,
+          }),
+        },
+      ],
+    });
+    analysisScheduleRule.cfnOptions.condition = hasCloudTrailBucket;
+
+    // Outputs for cross-stack references
+    new cdk.CfnOutput(this, UsageAnalysisStackOutputs.CloudTrailAnalyzerLambdaName, {
+      value: cloudtrailAnalyzerLambdaName,
+    });
+    new cdk.CfnOutput(this, UsageAnalysisStackOutputs.CloudFormationAnalyzerLambdaName, {
+      value: cloudformationAnalyzerLambdaName,
+    });
+    new cdk.CfnOutput(this, UsageAnalysisStackOutputs.UsageDecoratorLambdaName, {
+      value: usageDecoratorLambdaName,
+    });
+    new cdk.CfnOutput(this, UsageAnalysisStackOutputs.AnalysisStateMachineArn, {
+      value: cdk.Fn.ref(stateMachine.logicalId),
+    });
+    // Surfaced for the integration test runner so it can self-discover
+    // which CloudTrail bucket the analyzers will read from. Construct id
+    // can't reuse `CloudTrailBucketName` (already taken by the parameter).
+    new cdk.CfnOutput(this, UsageAnalysisStackOutputs.ConfiguredCloudTrailBucketName, {
+      value: cloudTrailBucketNameParameter.valueAsString,
+    });
+  }
+}

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capability-insights/constructs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "private": true,
   "main": "dist/lib/index.js",

--- a/source/constructs/scripts/package-template.mjs
+++ b/source/constructs/scripts/package-template.mjs
@@ -9,3 +9,13 @@ fs.writeFileSync(
   '../../deployment/dist/template/capability-insights.template.json',
   JSON.stringify(stripCdkMetadata(raw), null, 2),
 );
+
+// Package Usage Analysis stack template if it exists
+const usageAnalysisPath = 'build/cdk.out/CapabilityInsightsUsageAnalysis.template.json';
+if (fs.existsSync(usageAnalysisPath)) {
+  const usageRaw = JSON.parse(fs.readFileSync(usageAnalysisPath, 'utf8'));
+  fs.writeFileSync(
+    '../../deployment/dist/template/usage-analysis.template.json',
+    JSON.stringify(stripCdkMetadata(usageRaw), null, 2),
+  );
+}

--- a/source/lambda/analyze-route.test.ts
+++ b/source/lambda/analyze-route.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleAnalyze } from './routes/analyze-route';
+import { SFNClient, StartExecutionCommand, DescribeExecutionCommand } from '@aws-sdk/client-sfn';
+import { OrganizationsClient, ListAccountsCommand } from '@aws-sdk/client-organizations';
+import { mockClient } from 'aws-sdk-client-mock';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+const sfnMock = mockClient(SFNClient);
+const orgsMock = mockClient(OrganizationsClient);
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    httpMethod: 'POST',
+    path: '/analysis',
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'test',
+      authorizer: null,
+      protocol: 'HTTP/1.1',
+      httpMethod: 'POST',
+      identity: {} as APIGatewayProxyEvent['requestContext']['identity'],
+      path: '/analysis',
+      stage: 'prod',
+      requestId: 'test-id',
+      requestTimeEpoch: 0,
+      resourceId: '',
+      resourcePath: '',
+    },
+    ...overrides,
+  };
+}
+
+describe('analyze-route', () => {
+  beforeEach(() => {
+    sfnMock.reset();
+    orgsMock.reset();
+    vi.stubEnv('ANALYSIS_STATE_MACHINE_ARN', 'arn:aws:states:us-east-1:123:stateMachine:test');
+    vi.stubEnv('WEBSITE_BUCKET_NAME', 'test-bucket');
+    vi.stubEnv('CLOUDTRAIL_ANALYZER_LAMBDA_NAME', 'TestAnalyzer');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('POST /analysis', () => {
+    it('starts a Step Functions execution and returns 202', async () => {
+      sfnMock.on(StartExecutionCommand).resolves({
+        executionArn: 'arn:aws:states:us-east-1:123:execution:test:run-1',
+      });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'account',
+          analyzerParams: { cloudtrail: { bucket: 'my-trail-bucket' } },
+        }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(202);
+
+      const body = JSON.parse(result.body);
+      expect(body.status).toBe('RUNNING');
+      expect(body.executionArn).toBe('arn:aws:states:us-east-1:123:execution:test:run-1');
+    });
+
+    it('returns 400 when scope is missing', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({ analyzerParams: { cloudtrail: { bucket: 'b' } } }),
+      });
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body).error).toContain('scope');
+    });
+
+    it('returns 400 when cloudtrail bucket is missing', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({ scope: 'account' }),
+      });
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body).error).toContain('cloudtrail.bucket');
+    });
+
+    it('falls back to CONFIGURED_CLOUDTRAIL_BUCKET env var when bucket is omitted from the request', async () => {
+      vi.stubEnv('CONFIGURED_CLOUDTRAIL_BUCKET', 'env-fallback-bucket');
+      sfnMock.on(StartExecutionCommand).resolves({
+        executionArn: 'arn:aws:states:us-east-1:123:execution:test:fallback-run',
+      });
+
+      const event = makeEvent({
+        body: JSON.stringify({ scope: 'account' }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(202);
+
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.cloudTrailBucket).toBe('env-fallback-bucket');
+    });
+
+    it('prefers analyzerParams.cloudtrail.bucket over CONFIGURED_CLOUDTRAIL_BUCKET when both are set', async () => {
+      vi.stubEnv('CONFIGURED_CLOUDTRAIL_BUCKET', 'env-fallback-bucket');
+      sfnMock.on(StartExecutionCommand).resolves({
+        executionArn: 'arn:aws:states:us-east-1:123:execution:test:override-run',
+      });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'account',
+          analyzerParams: { cloudtrail: { bucket: 'request-body-bucket' } },
+        }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(202);
+
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.cloudTrailBucket).toBe('request-body-bucket');
+    });
+
+    it('returns 503 when state machine ARN is not configured (Usage Analysis stack not deployed)', async () => {
+      vi.stubEnv('ANALYSIS_STATE_MACHINE_ARN', '');
+      delete process.env.ANALYSIS_STATE_MACHINE_ARN;
+
+      const event = makeEvent({
+        body: JSON.stringify({ scope: 'account' }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(503);
+      const body = JSON.parse(result.body) as { error: string; message: string };
+      expect(body.error).toContain('Usage Analysis is not enabled');
+      expect(body.message).toContain('--enable-usage-analysis');
+    });
+
+    it('uses default analyzers when not specified', async () => {
+      sfnMock.on(StartExecutionCommand).resolves({
+        executionArn: 'arn:aws:states:us-east-1:123:execution:test:run-1',
+      });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'account',
+          analyzerParams: { cloudtrail: { bucket: 'my-trail-bucket' } },
+        }),
+      });
+
+      await handleAnalyze(event);
+
+      const call = sfnMock.commandCalls(StartExecutionCommand)[0];
+      const input = JSON.parse(call.args[0].input.input!);
+      expect(input.analyzers).toEqual(['cloudtrail', 'cloudformation']);
+    });
+  });
+
+  describe('GET /analysis', () => {
+    it('returns RUNNING status for in-progress execution', async () => {
+      sfnMock.on(DescribeExecutionCommand).resolves({
+        status: 'RUNNING',
+      });
+
+      const event = makeEvent({
+        httpMethod: 'GET',
+        queryStringParameters: {
+          executionArn: 'arn:aws:states:us-east-1:123:execution:test:run-1',
+        },
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(200);
+      expect(JSON.parse(result.body).status).toBe('RUNNING');
+    });
+
+    it('returns results for succeeded execution', async () => {
+      const output = { cloudtrail: { '123': { s3: { apis: ['GetObject'] } } } };
+      sfnMock.on(DescribeExecutionCommand).resolves({
+        status: 'SUCCEEDED',
+        output: JSON.stringify(output),
+      });
+
+      const event = makeEvent({
+        httpMethod: 'GET',
+        queryStringParameters: {
+          executionArn: 'arn:aws:states:us-east-1:123:execution:test:run-1',
+        },
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(200);
+      expect(JSON.parse(result.body)).toEqual(output);
+    });
+
+    it('returns FAILED status with error details', async () => {
+      sfnMock.on(DescribeExecutionCommand).resolves({
+        status: 'FAILED',
+        error: 'Lambda.Timeout',
+        cause: 'Function timed out',
+      });
+
+      const event = makeEvent({
+        httpMethod: 'GET',
+        queryStringParameters: {
+          executionArn: 'arn:aws:states:us-east-1:123:execution:test:run-1',
+        },
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.status).toBe('FAILED');
+      expect(body.error).toBe('Function timed out');
+    });
+
+    it('returns 400 when executionArn is missing', async () => {
+      const event = makeEvent({
+        httpMethod: 'GET',
+        queryStringParameters: null,
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body).error).toContain('executionArn');
+    });
+  });
+
+  describe('POST /analysis with scope=organization', () => {
+    it('discovers active accounts via Organizations and passes them to the state machine', async () => {
+      orgsMock
+        .on(ListAccountsCommand, { NextToken: undefined })
+        .resolves({
+          Accounts: [
+            { Id: '111111111111', Status: 'ACTIVE' },
+            { Id: '222222222222', Status: 'ACTIVE' },
+          ],
+          NextToken: 'page-2',
+        })
+        .on(ListAccountsCommand, { NextToken: 'page-2' })
+        .resolves({
+          Accounts: [
+            { Id: '333333333333', Status: 'ACTIVE' },
+            { Id: '999999999999', Status: 'SUSPENDED' },
+          ],
+        });
+
+      sfnMock.on(StartExecutionCommand).resolves({
+        executionArn: 'arn:aws:states:us-east-1:123:execution:test:org-run-1',
+      });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'organization',
+          analyzerParams: { cloudtrail: { bucket: 'org-trail-bucket' } },
+        }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(202);
+
+      const sfnCall = sfnMock.commandCalls(StartExecutionCommand)[0];
+      const input = JSON.parse(sfnCall.args[0].input.input!);
+      expect(input.scope).toBe('organization');
+      expect(input.accounts).toEqual(['111111111111', '222222222222', '333333333333']);
+
+      expect(orgsMock.commandCalls(ListAccountsCommand)).toHaveLength(2);
+    });
+
+    it('still returns 202 when the organization has a single active account', async () => {
+      orgsMock.on(ListAccountsCommand).resolves({
+        Accounts: [{ Id: '111111111111', Status: 'ACTIVE' }],
+      });
+      sfnMock.on(StartExecutionCommand).resolves({
+        executionArn: 'arn:aws:states:us-east-1:123:execution:test:org-run-2',
+      });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'organization',
+          analyzerParams: { cloudtrail: { bucket: 'org-trail-bucket' } },
+        }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(202);
+
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.accounts).toEqual(['111111111111']);
+    });
+
+    it('returns 500 when the Organizations API fails', async () => {
+      orgsMock.on(ListAccountsCommand).rejects(new Error('AWSOrganizationsNotInUseException'));
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'organization',
+          analyzerParams: { cloudtrail: { bucket: 'org-trail-bucket' } },
+        }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(500);
+      expect(JSON.parse(result.body).error).toContain('Analysis failed');
+
+      expect(sfnMock.commandCalls(StartExecutionCommand)).toHaveLength(0);
+    });
+
+    it('ignores provided accountIds when scope is organization', async () => {
+      orgsMock.on(ListAccountsCommand).resolves({
+        Accounts: [
+          { Id: '111111111111', Status: 'ACTIVE' },
+          { Id: '222222222222', Status: 'ACTIVE' },
+        ],
+      });
+      sfnMock.on(StartExecutionCommand).resolves({ executionArn: 'arn:...' });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'organization',
+          accountIds: ['999999999999'], // should be ignored
+          analyzerParams: { cloudtrail: { bucket: 'org-trail-bucket' } },
+        }),
+      });
+
+      await handleAnalyze(event);
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.accounts).toEqual(['111111111111', '222222222222']);
+      expect(input.accounts).not.toContain('999999999999');
+    });
+
+    it('returns 202 with an empty accounts list when no active accounts are found', async () => {
+      // Locks in current behavior (forwards [] to SFN). Update intentionally if we move to fail-fast.
+      orgsMock.on(ListAccountsCommand).resolves({
+        Accounts: [
+          { Id: '111111111111', Status: 'SUSPENDED' },
+          { Id: '222222222222', Status: 'SUSPENDED' },
+        ],
+      });
+      sfnMock.on(StartExecutionCommand).resolves({ executionArn: 'arn:...' });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'organization',
+          analyzerParams: { cloudtrail: { bucket: 'org-trail-bucket' } },
+        }),
+      });
+
+      const result = await handleAnalyze(event);
+      expect(result.statusCode).toBe(202);
+
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.accounts).toEqual([]);
+    });
+
+    it('forwards CloudTrail analyzerParams to the state machine input', async () => {
+      // Locks in the flattening contract (analyzerParams.cloudtrail.* → cloudTrailBucket / cloudTrailPrefix / daysToScan).
+      orgsMock.on(ListAccountsCommand).resolves({
+        Accounts: [{ Id: '111111111111', Status: 'ACTIVE' }],
+      });
+      sfnMock.on(StartExecutionCommand).resolves({ executionArn: 'arn:...' });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'organization',
+          analyzers: ['cloudtrail', 'cloudformation'],
+          analyzerParams: {
+            cloudtrail: {
+              bucket: 'my-trail-bucket',
+              prefix: 'CustomPrefix/',
+              daysToScan: 30,
+            },
+          },
+        }),
+      });
+
+      await handleAnalyze(event);
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.cloudTrailBucket).toBe('my-trail-bucket');
+      expect(input.cloudTrailPrefix).toBe('CustomPrefix/');
+      expect(input.daysToScan).toBe(30);
+      expect(input.analyzers).toEqual(['cloudtrail', 'cloudformation']);
+    });
+  });
+
+  describe('POST /analysis with scope=account', () => {
+    it('uses provided accountIds when supplied', async () => {
+      sfnMock.on(StartExecutionCommand).resolves({ executionArn: 'arn:...' });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'account',
+          accountIds: ['111111111111', '222222222222'],
+          analyzerParams: { cloudtrail: { bucket: 'b' } },
+        }),
+      });
+
+      await handleAnalyze(event);
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.accounts).toEqual(['111111111111', '222222222222']);
+
+      expect(orgsMock.commandCalls(ListAccountsCommand)).toHaveLength(0);
+    });
+
+    it('falls back to the invoking account when accountIds is omitted', async () => {
+      sfnMock.on(StartExecutionCommand).resolves({ executionArn: 'arn:...' });
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          scope: 'account',
+          analyzerParams: { cloudtrail: { bucket: 'b' } },
+        }),
+      });
+
+      await handleAnalyze(event);
+      const input = JSON.parse(sfnMock.commandCalls(StartExecutionCommand)[0].args[0].input.input!);
+      expect(input.accounts).toEqual(['123456789012']);
+    });
+  });
+});

--- a/source/lambda/api-lambda-main.ts
+++ b/source/lambda/api-lambda-main.ts
@@ -4,6 +4,8 @@ import { HttpMethod } from './constants/http-methods';
 import { ErrorResponse } from './constants/errors';
 import { logger } from './util/logger';
 import { syncCapabilityDataRoute } from './routes/sync-capability-data-route';
+import { handleAnalyze } from './routes/analyze-route';
+import { getUsedCapabilities } from './routes/usage-route';
 const routes: Map<string, RouteHandler> = new Map();
 
 function registerRoute(method: string, path: string, handler: RouteHandler) {
@@ -12,6 +14,11 @@ function registerRoute(method: string, path: string, handler: RouteHandler) {
 
 // --- Register routes ---
 registerRoute(HttpMethod.POST, '/syncCapabilityData', syncCapabilityDataRoute);
+// Usage analysis: start analysis (POST) and poll status (GET)
+registerRoute(HttpMethod.POST, '/analysis', handleAnalyze);
+registerRoute(HttpMethod.GET, '/analysis', handleAnalyze);
+// Account-aware filtering: returns services/APIs based on usage data
+registerRoute(HttpMethod.GET, '/capabilities', getUsedCapabilities);
 
 // --- Main handler ---
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {

--- a/source/lambda/cloudformation-analyzer.test.ts
+++ b/source/lambda/cloudformation-analyzer.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handler } from './cloudformation-analyzer';
+import { CloudFormationClient, StackSummary } from '@aws-sdk/client-cloudformation';
+import { S3Client } from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import * as cloudformationClient from './services/cloudformation-client';
+
+const cfnMock = mockClient(CloudFormationClient);
+const s3Mock = mockClient(S3Client);
+
+const stack = (name: string, status = 'CREATE_COMPLETE'): StackSummary => ({
+  StackName: name,
+  StackStatus: status as StackSummary['StackStatus'],
+  CreationTime: new Date('2024-01-01T00:00:00Z'),
+});
+
+describe('cloudformation-analyzer', () => {
+  beforeEach(() => {
+    cfnMock.reset();
+    s3Mock.reset();
+    vi.clearAllMocks();
+    vi.stubEnv('AWS_REGION', 'us-east-1');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('handler', () => {
+    it('returns flat records with stack/service/resourceType metadata', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([stack('AppStack')]);
+      vi.spyOn(cloudformationClient, 'getProcessedTemplate').mockResolvedValue({
+        Resources: {
+          MyFunction: {
+            Type: 'AWS::Lambda::Function',
+            Properties: { Runtime: 'python3.11', MemorySize: 256 },
+          },
+          MyInstance: {
+            Type: 'AWS::EC2::Instance',
+            Properties: { InstanceType: 't3.medium' },
+          },
+        },
+      });
+
+      const result = await handler({ accountId: '123456789012', websiteBucket: 'test-bucket' });
+
+      expect(result.accountId).toBe('123456789012');
+      expect(result.region).toBe('us-east-1');
+      expect(result.records).toHaveLength(2);
+
+      const lambdaRecord = result.records.find(r => r.serviceName === 'Lambda');
+      expect(lambdaRecord).toMatchObject({
+        stackName: 'AppStack',
+        serviceName: 'Lambda',
+        resourceTypeName: 'Function',
+        properties: { Runtime: ['python3.11'], MemorySize: ['256'] },
+      });
+
+      const ec2Record = result.records.find(r => r.serviceName === 'EC2');
+      expect(ec2Record).toMatchObject({
+        stackName: 'AppStack',
+        serviceName: 'EC2',
+        resourceTypeName: 'Instance',
+        properties: { InstanceType: ['t3.medium'] },
+      });
+    });
+
+    it('dedupes property values within the same stack + resource type', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([stack('Stack1')]);
+      vi.spyOn(cloudformationClient, 'getProcessedTemplate').mockResolvedValue({
+        Resources: {
+          Fn1: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'python3.11' } },
+          Fn2: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'python3.11' } },
+          Fn3: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'nodejs18.x' } },
+        },
+      });
+
+      const result = await handler({ accountId: '123456789012' });
+
+      expect(result.records).toHaveLength(1);
+      expect(result.records[0].properties.Runtime.sort()).toEqual(['nodejs18.x', 'python3.11']);
+    });
+
+    it('produces separate records per stack', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([
+        stack('Stack1'),
+        stack('Stack2', 'UPDATE_COMPLETE'),
+      ]);
+      const getTemplateSpy = vi.spyOn(cloudformationClient, 'getProcessedTemplate');
+      getTemplateSpy.mockResolvedValueOnce({
+        Resources: {
+          Fn1: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'python3.11' } },
+        },
+      });
+      getTemplateSpy.mockResolvedValueOnce({
+        Resources: {
+          Fn2: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'nodejs20.x' } },
+        },
+      });
+
+      const result = await handler({ accountId: '123456789012' });
+
+      expect(result.records).toHaveLength(2);
+      const stackNames = result.records.map(r => r.stackName).sort();
+      expect(stackNames).toEqual(['Stack1', 'Stack2']);
+    });
+
+    it('skips non-AWS resource types', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([stack('AppStack')]);
+      vi.spyOn(cloudformationClient, 'getProcessedTemplate').mockResolvedValue({
+        Resources: {
+          CustomThing: { Type: 'Custom::MyResource', Properties: { Foo: 'bar' } },
+          LambdaFn: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'python3.11' } },
+        },
+      });
+
+      const result = await handler({ accountId: '123456789012' });
+
+      expect(result.records).toHaveLength(1);
+      expect(result.records[0].serviceName).toBe('Lambda');
+    });
+
+    it('handles stacks with missing templates', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([stack('BrokenStack')]);
+      vi.spyOn(cloudformationClient, 'getProcessedTemplate').mockResolvedValue(null);
+
+      const result = await handler({ accountId: '123456789012' });
+
+      expect(result.records).toEqual([]);
+    });
+
+    it('handles empty stack list', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([]);
+
+      const result = await handler({ accountId: '123456789012' });
+
+      expect(result).toEqual({ accountId: '123456789012', region: 'us-east-1', records: [] });
+    });
+
+    it('skips non-scalar property values', async () => {
+      vi.spyOn(cloudformationClient, 'listActiveStacks').mockResolvedValue([stack('AppStack')]);
+      vi.spyOn(cloudformationClient, 'getProcessedTemplate').mockResolvedValue({
+        Resources: {
+          MyBucket: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'my-bucket',
+              VersioningConfiguration: { Status: 'Enabled' }, // object — should be skipped
+              Tags: [{ Key: 'env', Value: 'prod' }], // array — should be skipped
+            },
+          },
+        },
+      });
+
+      const result = await handler({ accountId: '123456789012' });
+
+      expect(result.records[0].properties).toEqual({ BucketName: ['my-bucket'] });
+    });
+  });
+});

--- a/source/lambda/cloudformation-analyzer.ts
+++ b/source/lambda/cloudformation-analyzer.ts
@@ -1,0 +1,171 @@
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { AWS_RESOURCE_TYPE_PREFIX } from './constants/cloudformation';
+import { listActiveStacks, getProcessedTemplate } from './services/cloudformation-client';
+import { S3BucketClient } from './services/s3-client';
+import type { CloudFormationUsage, CloudFormationUsageRecord } from './types/usage';
+import { logger } from './util/logger';
+
+/**
+ * Lambda handler for CloudFormation usage analysis.
+ *
+ * Lists active CloudFormation stacks, fetches processed templates, extracts
+ * resource types and properties, maps to service names, and writes results
+ * to S3. Invoked by the Step Functions analysis state machine.
+ *
+ * Data handling:
+ * - Reads: every active stack's processed template via GetTemplate
+ * - Extracts: resource types (e.g., AWS::Lambda::Function) and scalar property
+ *   values (strings, numbers, booleans) keyed by resource type
+ * - Ignores: nested objects, arrays, and non-AWS resource types (Custom::*)
+ * - Writes: aggregated results to the website bucket's usage/ prefix
+ *
+ * Templates may contain sensitive configuration (ARNs, IDs, KMS references).
+ * Output is written only to the VPC-restricted website bucket.
+ */
+export const handler = async (event: {
+  accountId?: string;
+  accounts?: string[];
+  websiteBucket?: string;
+  analyzers?: string[];
+}): Promise<CloudFormationUsage> => {
+  // Skip if this analyzer wasn't requested
+  if (event.analyzers && !event.analyzers.includes('cloudformation')) {
+    logger.info('CloudFormation analyzer not requested, skipping');
+    return { accountId: '', region: '', records: [] };
+  }
+
+  const cfn = new CloudFormationClient({});
+  const websiteBucket = event.websiteBucket;
+  const accountId = event.accountId || event.accounts?.[0] || '';
+  const region = process.env.AWS_REGION || '';
+
+  logger.info('Starting CloudFormation analysis', { accountId, region });
+
+  const stacks = await listActiveStacks(cfn);
+  logger.info(`Found ${stacks.length} active stacks`);
+
+  // Per-stack aggregation: stack → resourceType → { properties }
+  // Keyed this way so one stack with multiple resources of the same type
+  // produces a single record with merged property values.
+  const aggregated: Record<string, Record<string, Record<string, Set<string>>>> = {};
+
+  // Process stacks in batches to avoid exceeding the Lambda timeout
+  // when accounts have hundreds of stacks. Tuned for GetTemplate's
+  // rate limits (~10 req/s) with headroom for retries.
+  const STACK_FETCH_CONCURRENCY = 5;
+  const stackNames = stacks.map(s => s.StackName).filter((name): name is string => !!name);
+
+  for (let i = 0; i < stackNames.length; i += STACK_FETCH_CONCURRENCY) {
+    const batch = stackNames.slice(i, i + STACK_FETCH_CONCURRENCY);
+    const templates = await Promise.allSettled(batch.map(name => getProcessedTemplate(cfn, name)));
+
+    for (let j = 0; j < batch.length; j++) {
+      const result = templates[j];
+      if (result.status === 'fulfilled' && result.value) {
+        processTemplate(result.value, batch[j], aggregated);
+      }
+    }
+  }
+
+  const records = buildRecords(aggregated);
+  const usage: CloudFormationUsage = { accountId, region, records };
+
+  logger.info('CloudFormation analysis complete', {
+    accountId,
+    region,
+    totalRecords: records.length,
+    stacks: Object.keys(aggregated).length,
+  });
+
+  if (websiteBucket) {
+    const s3Client = new S3BucketClient(websiteBucket);
+    const timestamp = new Date().toISOString();
+    const key = `usage/cloudformation-usage-${timestamp}.json`;
+    await s3Client.putObject(key, JSON.stringify(usage), 'application/json');
+    logger.info(`Saved CloudFormation usage to ${key}`);
+  }
+
+  return usage;
+};
+
+/**
+ * Extracts AWS resource types from a template's Resources section and
+ * aggregates them into the per-stack accumulator.
+ */
+function processTemplate(
+  template: Record<string, unknown>,
+  stackName: string,
+  aggregated: Record<string, Record<string, Record<string, Set<string>>>>,
+): void {
+  const resources = template.Resources as
+    | Record<string, { Type?: string; Properties?: Record<string, unknown> }>
+    | undefined;
+  if (!resources) return;
+
+  for (const resource of Object.values(resources)) {
+    const resourceType = resource.Type;
+    if (!resourceType || !resourceType.startsWith(AWS_RESOURCE_TYPE_PREFIX)) continue;
+
+    const [serviceName, resourceTypeName] = parseResourceType(resourceType);
+    if (!serviceName || !resourceTypeName) continue;
+
+    const fqn = `${serviceName}::${resourceTypeName}`;
+    if (!aggregated[stackName]) aggregated[stackName] = {};
+    if (!aggregated[stackName][fqn]) aggregated[stackName][fqn] = {};
+
+    if (resource.Properties) {
+      extractProperties(resource.Properties, aggregated[stackName][fqn]);
+    }
+  }
+}
+
+/**
+ * Parses a CloudFormation resource type string into [serviceName, resourceTypeName].
+ * Example: "AWS::Lambda::Function" → ["Lambda", "Function"].
+ */
+function parseResourceType(resourceType: string): [string, string] {
+  const parts = resourceType.split('::');
+  if (parts.length < 3) return ['', ''];
+  return [parts[1], parts.slice(2).join('::')];
+}
+
+/**
+ * Collects scalar property values into string-array sets for deduplication.
+ * Non-scalar properties (objects, arrays) are skipped intentionally:
+ * - Nested objects (e.g., Environment.Variables, VpcConfig) can contain
+ *   sensitive values and bloat the output without adding capability signal.
+ * - Arrays have no stable flattening rule across resource types.
+ * - The downstream use case is capability matching by resource type, which
+ *   doesn't require nested property values.
+ *
+ * If a future use case needs nested data, consider flattening specific known
+ * keys rather than recursing generically.
+ */
+function extractProperties(properties: Record<string, unknown>, accumulator: Record<string, Set<string>>): void {
+  for (const [key, value] of Object.entries(properties)) {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      if (!accumulator[key]) accumulator[key] = new Set();
+      accumulator[key].add(String(value));
+    }
+  }
+}
+
+/** Flattens the per-stack accumulator into an array of records. */
+function buildRecords(
+  aggregated: Record<string, Record<string, Record<string, Set<string>>>>,
+): CloudFormationUsageRecord[] {
+  const records: CloudFormationUsageRecord[] = [];
+
+  for (const [stackName, resourceTypes] of Object.entries(aggregated)) {
+    for (const [fqn, propertySets] of Object.entries(resourceTypes)) {
+      const [serviceName, resourceTypeName] = fqn.split('::');
+      const properties: Record<string, string[]> = {};
+      for (const [key, values] of Object.entries(propertySets)) {
+        properties[key] = Array.from(values);
+      }
+      records.push({ stackName, serviceName, resourceTypeName, properties });
+    }
+  }
+
+  return records;
+}

--- a/source/lambda/cloudtrail-analyzer.test.ts
+++ b/source/lambda/cloudtrail-analyzer.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handler } from './cloudtrail-analyzer';
+import { AthenaClient } from '@aws-sdk/client-athena';
+import { S3Client } from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import * as athenaClient from './services/athena-client';
+
+const athenaMock = mockClient(AthenaClient);
+const s3Mock = mockClient(S3Client);
+
+describe('cloudtrail-analyzer', () => {
+  beforeEach(() => {
+    athenaMock.reset();
+    s3Mock.reset();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handler', () => {
+    it('processes CloudTrail data and returns usage with apis and regionApis', async () => {
+      const mockQueryResults = [
+        ['s3.amazonaws.com', 'GetObject', 'us-east-1', '123456789012'],
+        ['s3.amazonaws.com', 'PutObject', 'us-east-1', '123456789012'],
+        ['s3.amazonaws.com', 'GetObject', 'us-west-2', '123456789012'],
+        ['ec2.amazonaws.com', 'DescribeInstances', 'us-east-1', '123456789012'],
+      ];
+
+      vi.spyOn(athenaClient, 'queryCloudTrailUsage').mockResolvedValue(mockQueryResults);
+
+      const result = await handler({
+        cloudTrailBucket: 'test-bucket',
+        cloudTrailPrefix: 'AWSLogs/',
+        daysToScan: 7,
+        websiteBucket: 'website-bucket',
+      });
+
+      expect(result).toHaveProperty('123456789012');
+      expect(result['123456789012']).toHaveProperty('s3');
+      expect(result['123456789012']).toHaveProperty('ec2');
+
+      // Check s3 service
+      const s3Service = result['123456789012'].s3;
+      expect(s3Service.apis).toEqual(['GetObject', 'PutObject']);
+      expect(s3Service.regionApis).toEqual({
+        'us-east-1': ['GetObject', 'PutObject'],
+        'us-west-2': ['GetObject'],
+      });
+
+      // Check ec2 service
+      const ec2Service = result['123456789012'].ec2;
+      expect(ec2Service.apis).toEqual(['DescribeInstances']);
+      expect(ec2Service.regionApis).toEqual({
+        'us-east-1': ['DescribeInstances'],
+      });
+    });
+
+    it('handles multiple accounts', async () => {
+      const mockQueryResults = [
+        ['lambda.amazonaws.com', 'Invoke', 'us-east-1', '123456789012'],
+        ['lambda.amazonaws.com', 'ListFunctions', 'us-west-2', '987654321098'],
+      ];
+
+      vi.spyOn(athenaClient, 'queryCloudTrailUsage').mockResolvedValue(mockQueryResults);
+
+      const result = await handler({
+        cloudTrailBucket: 'test-bucket',
+        cloudTrailPrefix: 'AWSLogs/',
+      });
+
+      expect(Object.keys(result)).toEqual(['123456789012', '987654321098']);
+      expect(result['123456789012'].lambda.apis).toEqual(['Invoke']);
+      expect(result['987654321098'].lambda.apis).toEqual(['ListFunctions']);
+    });
+
+    it('aggregates same API across multiple regions', async () => {
+      const mockQueryResults = [
+        ['dynamodb.amazonaws.com', 'Query', 'us-east-1', '123456789012'],
+        ['dynamodb.amazonaws.com', 'Query', 'eu-west-1', '123456789012'],
+        ['dynamodb.amazonaws.com', 'PutItem', 'us-east-1', '123456789012'],
+      ];
+
+      vi.spyOn(athenaClient, 'queryCloudTrailUsage').mockResolvedValue(mockQueryResults);
+
+      const result = await handler({
+        cloudTrailBucket: 'test-bucket',
+        cloudTrailPrefix: 'AWSLogs/',
+      });
+
+      const dynamodb = result['123456789012'].dynamodb;
+      expect(dynamodb.apis).toEqual(['Query', 'PutItem']);
+      expect(dynamodb.regionApis).toEqual({
+        'us-east-1': ['Query', 'PutItem'],
+        'eu-west-1': ['Query'],
+      });
+    });
+
+    it('handles empty results', async () => {
+      vi.spyOn(athenaClient, 'queryCloudTrailUsage').mockResolvedValue([]);
+
+      const result = await handler({
+        cloudTrailBucket: 'test-bucket',
+        cloudTrailPrefix: 'AWSLogs/',
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it('strips .amazonaws.com from service names', async () => {
+      const mockQueryResults = [
+        ['s3.amazonaws.com', 'GetObject', 'us-east-1', '123456789012'],
+        ['lambda.amazonaws.com', 'Invoke', 'us-east-1', '123456789012'],
+      ];
+
+      vi.spyOn(athenaClient, 'queryCloudTrailUsage').mockResolvedValue(mockQueryResults);
+
+      const result = await handler({
+        cloudTrailBucket: 'test-bucket',
+        cloudTrailPrefix: 'AWSLogs/',
+      });
+
+      expect(result['123456789012']).toHaveProperty('s3');
+      expect(result['123456789012']).toHaveProperty('lambda');
+      expect(result['123456789012']).not.toHaveProperty('s3.amazonaws.com');
+    });
+
+    it('uses default values for optional parameters', async () => {
+      const queryUsageSpy = vi.spyOn(athenaClient, 'queryCloudTrailUsage').mockResolvedValue([]);
+
+      await handler({
+        cloudTrailBucket: 'test-bucket',
+        cloudTrailPrefix: 'AWSLogs/',
+      });
+
+      expect(queryUsageSpy).toHaveBeenCalledWith(
+        expect.any(AthenaClient),
+        'cloudtrail_analysis',
+        'cloudtrail_logs',
+        expect.stringContaining('athena-results/'),
+        30,
+      );
+    });
+  });
+});

--- a/source/lambda/cloudtrail-analyzer.ts
+++ b/source/lambda/cloudtrail-analyzer.ts
@@ -1,0 +1,102 @@
+import { AthenaClient } from '@aws-sdk/client-athena';
+import { AthenaDefaults } from './constants/athena';
+import { queryCloudTrailUsage } from './services/athena-client';
+import { S3BucketClient } from './services/s3-client';
+import type { CloudTrailUsage } from './types/usage';
+import { logger } from './util/logger';
+
+/**
+ * Lambda handler for CloudTrail usage analysis.
+ *
+ * Uses Athena to query CloudTrail logs, extracts distinct service/API/region
+ * combinations per account, and writes results to S3. Invoked by the
+ * Step Functions analysis state machine.
+ */
+export const handler = async (event: {
+  cloudTrailBucket: string;
+  cloudTrailPrefix: string;
+  athenaDatabase?: string;
+  athenaResultsLocation?: string;
+  daysToScan?: number;
+  websiteBucket?: string;
+  analyzers?: string[];
+}): Promise<CloudTrailUsage> => {
+  // Skip if this analyzer wasn't requested
+  if (event.analyzers && !event.analyzers.includes('cloudtrail')) {
+    logger.info('CloudTrail analyzer not requested, skipping');
+    return {};
+  }
+
+  const athena = new AthenaClient({});
+  const websiteBucket = event.websiteBucket;
+  const database = event.athenaDatabase || AthenaDefaults.DATABASE;
+  const tableName = AthenaDefaults.TABLE_NAME;
+  const resultsLocation = event.athenaResultsLocation || `s3://${websiteBucket}/athena-results/`;
+  const daysToScan = event.daysToScan || 30;
+
+  logger.info('Starting CloudTrail analysis', {
+    database,
+    daysToScan,
+  });
+
+  const results = await queryCloudTrailUsage(athena, database, tableName, resultsLocation, daysToScan);
+
+  logger.info(`Retrieved ${results.length} CloudTrail events`);
+
+  const usage: CloudTrailUsage = {};
+  const apiSets: Record<string, Record<string, Set<string>>> = {};
+  const regionApiSets: Record<string, Record<string, Record<string, Set<string>>>> = {};
+
+  for (const [eventsource, eventname, awsregion, accountid] of results) {
+    const service = (eventsource || '').replace('.amazonaws.com', '');
+    const account = accountid || '';
+    const api = eventname || '';
+    const region = awsregion || '';
+
+    // Skip rows with missing essential fields
+    if (!service || !account || !api) continue;
+
+    if (!apiSets[account]) apiSets[account] = {};
+    if (!regionApiSets[account]) regionApiSets[account] = {};
+
+    if (!apiSets[account][service]) apiSets[account][service] = new Set();
+    if (!regionApiSets[account][service]) regionApiSets[account][service] = {};
+    if (!regionApiSets[account][service][region]) regionApiSets[account][service][region] = new Set();
+
+    apiSets[account][service].add(api);
+    if (region) {
+      regionApiSets[account][service][region].add(api);
+    }
+  }
+
+  // Convert Sets to arrays for the output
+  for (const [account, services] of Object.entries(apiSets)) {
+    usage[account] = {};
+    for (const [service, apis] of Object.entries(services)) {
+      const regionApis: Record<string, string[]> = {};
+      for (const [region, regionSet] of Object.entries(regionApiSets[account][service])) {
+        regionApis[region] = Array.from(regionSet);
+      }
+      usage[account][service] = {
+        apis: Array.from(apis),
+        regionApis,
+      };
+    }
+  }
+
+  logger.info('CloudTrail analysis complete', {
+    accounts: Object.keys(usage).length,
+    services: Object.values(usage).reduce((sum, acct) => sum + Object.keys(acct).length, 0),
+  });
+
+  // Save usage file to S3
+  if (websiteBucket) {
+    const s3Client = new S3BucketClient(websiteBucket);
+    const timestamp = new Date().toISOString();
+    const key = `usage/cloudtrail-usage-${timestamp}.json`;
+    await s3Client.putObject(key, JSON.stringify(usage), 'application/json');
+    logger.info(`Saved CloudTrail usage to ${key}`);
+  }
+
+  return usage;
+};

--- a/source/lambda/constants/analysis.ts
+++ b/source/lambda/constants/analysis.ts
@@ -1,0 +1,24 @@
+/**
+ * Lambda-local copies of the analyze API enums. Mirrors
+ * `source/shared/types/analysis.ts` (which the website value-imports). They
+ * are duplicated here because the lambda runtime bundle does not include the
+ * shared workspace package — the existing convention in this repo is for
+ * lambda code to use its own local constants and import shared definitions
+ * only at the type level.
+ */
+
+export const ExecutionStatus = {
+  RUNNING: 'RUNNING',
+  SUCCEEDED: 'SUCCEEDED',
+  FAILED: 'FAILED',
+} as const;
+
+export type ExecutionStatus = (typeof ExecutionStatus)[keyof typeof ExecutionStatus];
+
+export const AnalyzerType = {
+  CLOUDTRAIL: 'cloudtrail',
+  RESOURCE_EXPLORER: 'resourceExplorer',
+  CLOUDFORMATION: 'cloudformation',
+} as const;
+
+export type AnalyzerType = (typeof AnalyzerType)[keyof typeof AnalyzerType];

--- a/source/lambda/constants/athena.ts
+++ b/source/lambda/constants/athena.ts
@@ -1,0 +1,13 @@
+/** Default Athena database and table names for CloudTrail analysis. */
+export const AthenaDefaults = {
+  DATABASE: 'cloudtrail_analysis',
+  TABLE_NAME: 'cloudtrail_logs',
+} as const;
+
+/** Athena query execution statuses. */
+export const AthenaQueryStatus = {
+  RUNNING: 'RUNNING',
+  QUEUED: 'QUEUED',
+  SUCCEEDED: 'SUCCEEDED',
+  FAILED: 'FAILED',
+} as const;

--- a/source/lambda/constants/cloudformation.ts
+++ b/source/lambda/constants/cloudformation.ts
@@ -1,0 +1,16 @@
+/** CloudFormation stack statuses considered "active" (deployed and usable). */
+export const ACTIVE_STACK_STATUSES = [
+  'CREATE_COMPLETE',
+  'UPDATE_COMPLETE',
+  'UPDATE_ROLLBACK_COMPLETE',
+  'IMPORT_COMPLETE',
+] as const;
+
+/** CloudFormation template stage — PROCESSED returns the fully resolved template. */
+export const TemplateStage = {
+  ORIGINAL: 'Original',
+  PROCESSED: 'Processed',
+} as const;
+
+/** Prefix that indicates a CloudFormation resource type belongs to AWS. */
+export const AWS_RESOURCE_TYPE_PREFIX = 'AWS::';

--- a/source/lambda/constants/cloudtrail-service-aliases.ts
+++ b/source/lambda/constants/cloudtrail-service-aliases.ts
@@ -1,0 +1,50 @@
+/**
+ * Known mismatches between CloudTrail event source names and the
+ * sdkServiceName values in apis.json.
+ *
+ * CloudTrail uses "public slug" style names (e.g., `monitoring.amazonaws.com`)
+ * while apis.json uses SDK client names (e.g., `CloudWatch`). This map
+ * bridges the most common mismatches so usage decoration can resolve them.
+ *
+ * Keys: the cleaned CloudTrail event source (lowercase, `.amazonaws.com` stripped)
+ * Values: the corresponding sdkServiceName as used in apis.json, lowercased
+ *
+ * Services omitted: services that have no entry in apis.json at all
+ * (e.g., Auto Scaling, EventBridge, STS) can't be mapped here — adding
+ * them wouldn't help until apis.json gains matching entries.
+ *
+ * Maintenance: when a new CloudTrail source is observed that doesn't
+ * resolve, check apis.json for the matching sdkServiceName and add an
+ * entry here. A build-time generator sourced from AWS SDK metadata is
+ * tracked as a follow-up (see PR #11 discussion).
+ */
+export const CLOUDTRAIL_SERVICE_ALIASES: Record<string, string> = {
+  // Compute / application
+  elasticloadbalancing: 'elastic load balancing',
+  elasticmapreduce: 'emr',
+  elasticfilesystem: 'efs',
+
+  // Observability / management
+  monitoring: 'cloudwatch',
+  logs: 'cloudwatch logs',
+  states: 'sfn',
+  config: 'config service',
+
+  // Database
+  dms: 'database migration service',
+
+  // Security / identity
+  'cognito-identity': 'cognito identity',
+  'cognito-idp': 'cognito identity', // same product as cognito-identity
+
+  // Networking
+  route53: 'route 53',
+
+  // Messaging
+  amazonmq: 'mq',
+
+  // Data
+  es: 'elasticsearch service', // CloudTrail uses "es" for OpenSearch (formerly Elasticsearch)
+  airflow: 'mwaa',
+  inspector: 'inspector2',
+};

--- a/source/lambda/constants/environment.ts
+++ b/source/lambda/constants/environment.ts
@@ -5,6 +5,25 @@ export const EnvironmentKey = {
   SOURCE_ACCESS_POINT_ARN: 'SOURCE_ACCESS_POINT_ARN',
   SOURCE_FOLDERS: 'SOURCE_FOLDERS',
   DATA_FETCH_LAMBDA_NAME: 'DATA_FETCH_LAMBDA_NAME',
+  CLOUDTRAIL_ANALYZER_LAMBDA_NAME: 'CLOUDTRAIL_ANALYZER_LAMBDA_NAME',
+  // TODO: Add these to the usage-analysis-stack and insights stack env vars once the analyzers are implemented
+  RESOURCE_EXPLORER_ANALYZER_LAMBDA_NAME: 'RESOURCE_EXPLORER_ANALYZER_LAMBDA_NAME',
+  CLOUDFORMATION_ANALYZER_LAMBDA_NAME: 'CLOUDFORMATION_ANALYZER_LAMBDA_NAME',
+  ANALYSIS_STATE_MACHINE_ARN: 'ANALYSIS_STATE_MACHINE_ARN',
+  /**
+   * Configured CloudTrail bucket from the Usage Analysis stack. When set, the
+   * analyze route uses it as a fallback if the request body omits
+   * `analyzerParams.cloudtrail.bucket`. This lets the UI trigger analysis
+   * without re-prompting for the bucket every time.
+   */
+  CONFIGURED_CLOUDTRAIL_BUCKET: 'CONFIGURED_CLOUDTRAIL_BUCKET',
+  /**
+   * When `"true"` (default), the usage decorator includes all `childProducts`
+   * (features) for every service kept in the personalized view — even features
+   * not individually detected as used. Set to `"false"` to narrow each service
+   * to only the features directly observed in usage data.
+   */
+  INCLUDE_ALL_FEATURES_PER_SERVICE: 'INCLUDE_ALL_FEATURES_PER_SERVICE',
 } as const;
 
 export type EnvironmentKey = (typeof EnvironmentKey)[keyof typeof EnvironmentKey];
@@ -13,4 +32,9 @@ export function getEnv(key: EnvironmentKey): string {
   const value = process.env[key];
   if (!value) throw new Error(`Missing required environment variable: ${key}`);
   return value;
+}
+
+/** Returns the environment variable value or a fallback if not set. */
+export function getOptionalEnv(key: EnvironmentKey, fallback = ''): string {
+  return process.env[key] ?? fallback;
 }

--- a/source/lambda/constants/scope.ts
+++ b/source/lambda/constants/scope.ts
@@ -1,0 +1,9 @@
+/** Analysis scope — single account or the entire AWS Organization. */
+export const Scope = {
+  ACCOUNT: 'account',
+  ORGANIZATION: 'organization',
+} as const;
+
+export type Scope = (typeof Scope)[keyof typeof Scope];
+
+export const VALID_SCOPES: Scope[] = [Scope.ACCOUNT, Scope.ORGANIZATION];

--- a/source/lambda/constants/status-codes.ts
+++ b/source/lambda/constants/status-codes.ts
@@ -1,6 +1,7 @@
 export const StatusCode = {
   OK: 200,
   CREATED: 201,
+  ACCEPTED: 202,
   NO_CONTENT: 204,
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,

--- a/source/lambda/constants/usage-filter.ts
+++ b/source/lambda/constants/usage-filter.ts
@@ -1,0 +1,14 @@
+/** Filter modes for the usage capabilities endpoint. */
+export const UsageFilter = {
+  DEPLOYED: 'deployed',
+  ACTIVE_USAGE: 'active_usage',
+  COMBINED: 'combined',
+} as const;
+
+export type UsageFilter = (typeof UsageFilter)[keyof typeof UsageFilter];
+
+export const VALID_USAGE_FILTERS: UsageFilter[] = [
+  UsageFilter.DEPLOYED,
+  UsageFilter.ACTIVE_USAGE,
+  UsageFilter.COMBINED,
+];

--- a/source/lambda/integration-tests/helpers/poll-execution.ts
+++ b/source/lambda/integration-tests/helpers/poll-execution.ts
@@ -1,0 +1,34 @@
+import { SFNClient, DescribeExecutionCommand } from '@aws-sdk/client-sfn';
+
+const TERMINAL = new Set(['SUCCEEDED', 'FAILED', 'TIMED_OUT', 'ABORTED']);
+
+export interface FinishedExecution {
+  status: string;
+  output?: string;
+  error?: string;
+  cause?: string;
+}
+
+/**
+ * Polls a Step Functions execution until it reaches a terminal status, or
+ * the deadline is hit. Returns the final DescribeExecution shape.
+ */
+export async function pollExecution(
+  sfn: SFNClient,
+  executionArn: string,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<FinishedExecution> {
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+  const intervalMs = options.intervalMs ?? 2000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = await sfn.send(new DescribeExecutionCommand({ executionArn }));
+    const status = result.status ?? 'UNKNOWN';
+    if (TERMINAL.has(status)) {
+      return { status, output: result.output, error: result.error, cause: result.cause };
+    }
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Execution ${executionArn} did not reach terminal status within ${timeoutMs}ms`);
+}

--- a/source/lambda/integration-tests/helpers/stack-outputs.ts
+++ b/source/lambda/integration-tests/helpers/stack-outputs.ts
@@ -1,0 +1,27 @@
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+
+/**
+ * Reads a deployed CloudFormation stack's outputs into a typed map.
+ *
+ * The integration test layer self-discovers everything (state-machine ARN,
+ * bucket names, lambda names) from these outputs so the test runner only
+ * needs the stack name(s) — not a long list of env vars to keep in sync
+ * with the CDK construct.
+ */
+export async function getStackOutputs(stackName: string): Promise<Record<string, string>> {
+  const cfn = new CloudFormationClient({});
+  const result = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+  const stack = result.Stacks?.[0];
+  if (!stack) throw new Error(`Stack not found: ${stackName}`);
+  const outputs: Record<string, string> = {};
+  for (const o of stack.Outputs ?? []) {
+    if (o.OutputKey && o.OutputValue !== undefined) outputs[o.OutputKey] = o.OutputValue;
+  }
+  return outputs;
+}
+
+export function requireOutput(outputs: Record<string, string>, key: string, stackName: string): string {
+  const value = outputs[key];
+  if (!value) throw new Error(`Stack ${stackName} is missing output: ${key}`);
+  return value;
+}

--- a/source/lambda/integration-tests/state-machine.it.test.ts
+++ b/source/lambda/integration-tests/state-machine.it.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test, beforeAll } from 'vitest';
+import { GetObjectCommand, HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { SFNClient, StartExecutionCommand } from '@aws-sdk/client-sfn';
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+
+import { getStackOutputs, requireOutput } from './helpers/stack-outputs';
+import { pollExecution } from './helpers/poll-execution';
+
+/**
+ * End-to-end test of the analysis state machine against a deployed stack.
+ *
+ * Hits real AWS — slow (60–120s), requires credentials, run on demand only:
+ *
+ *   npm run test:it --workspace=source/lambda
+ *
+ * Override defaults with env vars when stacks aren't named as expected:
+ *
+ *   INSIGHTS_STACK_NAME=MyInsightsStack \
+ *   USAGE_ANALYSIS_STACK_NAME=MyUsageStack \
+ *   DAYS_TO_SCAN=30 \
+ *   AWS_REGION=us-west-2 \
+ *   npm run test:it --workspace=source/lambda
+ *
+ * What it does:
+ *   1. Reads deployed CloudFormation stack outputs to discover the state
+ *      machine ARN, bucket names, and lambda names.
+ *   2. Captures the LastModified of each used-capabilities-account-*.json
+ *      file in the website bucket.
+ *   3. StartExecution on the state machine with a real input.
+ *   4. Polls until terminal status (max 5 minutes).
+ *   5. Asserts: status SUCCEEDED, all three used-* files have a newer
+ *      LastModified, the combined file is valid JSON with the expected
+ *      shape and at least one product / API / CFN resource.
+ *
+ * Preconditions (test fails fast if not met):
+ *   - AWS credentials available via the standard SDK credential chain
+ *     (env vars, ~/.aws/credentials, IAM role, IAM Identity Center, etc.).
+ *   - The two stacks are deployed (defaults below; override with env vars).
+ *   - Master-data files exist in the website bucket — the data-fetch lambda
+ *     has run at least once.
+ *   - CloudTrail bucket has at least a few days of logs.
+ *   - At least one active CloudFormation stack exists in the account.
+ *
+ * If the test data isn't there yet, provision a CloudFormation stack with
+ * a few resources, generate AWS API activity to populate CloudTrail, and
+ * wait 5–15 minutes for CloudTrail logs to land in S3 before running.
+ */
+const INSIGHTS_STACK = process.env.INSIGHTS_STACK_NAME ?? 'CapabilityInsightsForAWS';
+const USAGE_STACK = process.env.USAGE_ANALYSIS_STACK_NAME ?? 'CapabilityInsightsUsageAnalysis';
+const DAYS_TO_SCAN = Number(process.env.DAYS_TO_SCAN ?? 7);
+
+interface Resolved {
+  accountId: string;
+  region: string;
+  stateMachineArn: string;
+  websiteBucket: string;
+  cloudTrailBucket: string;
+  cloudtrailAnalyzerLambda: string;
+  cloudformationAnalyzerLambda: string;
+}
+
+async function resolveContext(): Promise<Resolved> {
+  const sts = new STSClient({});
+  const { Account } = await sts.send(new GetCallerIdentityCommand({}));
+  const region = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? 'us-east-1';
+
+  const insightsOutputs = await getStackOutputs(INSIGHTS_STACK);
+  const usageOutputs = await getStackOutputs(USAGE_STACK);
+
+  return {
+    accountId: Account!,
+    region,
+    websiteBucket: requireOutput(insightsOutputs, 'WebsiteBucketName', INSIGHTS_STACK),
+    stateMachineArn: requireOutput(usageOutputs, 'AnalysisStateMachineArn', USAGE_STACK),
+    cloudTrailBucket: requireOutput(usageOutputs, 'ConfiguredCloudTrailBucketName', USAGE_STACK),
+    cloudtrailAnalyzerLambda: requireOutput(usageOutputs, 'CloudTrailAnalyzerLambdaName', USAGE_STACK),
+    cloudformationAnalyzerLambda: requireOutput(usageOutputs, 'CloudFormationAnalyzerLambdaName', USAGE_STACK),
+  };
+}
+
+const USED_FILES = [
+  'data/json/used-capabilities-account-deployed.json',
+  'data/json/used-capabilities-account-active_usage.json',
+  'data/json/used-capabilities-account-combined.json',
+] as const;
+
+describe('analysis state machine — integration', () => {
+  let ctx: Resolved;
+  let s3: S3Client;
+  let sfn: SFNClient;
+
+  beforeAll(async () => {
+    ctx = await resolveContext();
+    s3 = new S3Client({ region: ctx.region });
+    sfn = new SFNClient({ region: ctx.region });
+  }, 30_000);
+
+  test(
+    'runs end-to-end and refreshes all three used-capabilities files',
+    async () => {
+      // Capture LastModified for each used-* file pre-run so we can prove they
+      // were actually rewritten by this execution (rather than reading a file
+      // a previous run left behind).
+      const before = await Promise.all(
+        USED_FILES.map(async key => {
+          try {
+            const head = await s3.send(new HeadObjectCommand({ Bucket: ctx.websiteBucket, Key: key }));
+            return { key, lastModified: head.LastModified };
+          } catch {
+            return { key, lastModified: undefined };
+          }
+        }),
+      );
+
+      const input = {
+        scope: 'account',
+        accounts: [ctx.accountId],
+        analyzers: ['cloudtrail', 'cloudformation'],
+        cloudTrailBucket: ctx.cloudTrailBucket,
+        cloudTrailPrefix: 'AWSLogs/',
+        daysToScan: DAYS_TO_SCAN,
+        websiteBucket: ctx.websiteBucket,
+        cloudtrailAnalyzerLambda: ctx.cloudtrailAnalyzerLambda,
+        cloudformationAnalyzerLambda: ctx.cloudformationAnalyzerLambda,
+        resourceExplorerAnalyzerLambda: '',
+      };
+
+      const start = await sfn.send(
+        new StartExecutionCommand({
+          stateMachineArn: ctx.stateMachineArn,
+          input: JSON.stringify(input),
+        }),
+      );
+      expect(start.executionArn).toBeDefined();
+
+      const finished = await pollExecution(sfn, start.executionArn!, {
+        timeoutMs: 5 * 60 * 1000,
+        intervalMs: 2000,
+      });
+      expect(finished.status).toBe('SUCCEEDED');
+
+      // Verify each used-* file was rewritten by this run.
+      for (const { key, lastModified: priorModified } of before) {
+        const head = await s3.send(new HeadObjectCommand({ Bucket: ctx.websiteBucket, Key: key }));
+        expect(head.LastModified).toBeDefined();
+        if (priorModified) {
+          expect(head.LastModified!.getTime()).toBeGreaterThan(priorModified.getTime());
+        }
+      }
+
+      // Sanity-check the combined file's shape and that it isn't empty.
+      const combinedKey = 'data/json/used-capabilities-account-combined.json';
+      const obj = await s3.send(new GetObjectCommand({ Bucket: ctx.websiteBucket, Key: combinedKey }));
+      const body = await obj.Body!.transformToString();
+      const parsed = JSON.parse(body);
+      expect(parsed).toHaveProperty('products');
+      expect(parsed).toHaveProperty('apis');
+      expect(parsed).toHaveProperty('cfnResources');
+      expect(parsed).toHaveProperty('lastAnalyzedAt');
+      expect(Array.isArray(parsed.products)).toBe(true);
+      expect(Array.isArray(parsed.apis)).toBe(true);
+      expect(Array.isArray(parsed.cfnResources)).toBe(true);
+      // At least one of the three should have content from a real account.
+      const total = parsed.products.length + parsed.apis.length + parsed.cfnResources.length;
+      expect(total).toBeGreaterThan(0);
+    },
+    6 * 60 * 1000,
+  );
+});

--- a/source/lambda/package.json
+++ b/source/lambda/package.json
@@ -1,18 +1,29 @@
 {
   "name": "@capability-insights/lambda",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "main": "index.js",
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
-    "package": "cd dist && zip -r ../../../deployment/dist/lambda/lambdaAssets.zip .",
-    "test": "vitest run"
+    "package": "rm -rf dist/node_modules && mkdir -p dist/node_modules && cp -R \"$(node -p 'path.dirname(require.resolve(\"js-yaml/package.json\"))')\" dist/node_modules/js-yaml && cp -R \"$(node -p 'path.dirname(require.resolve(\"argparse/package.json\"))')\" dist/node_modules/argparse && cd dist && rm -f ../../../deployment/dist/lambda/lambdaAssets.zip && zip -r ../../../deployment/dist/lambda/lambdaAssets.zip . -x 'node_modules/@*'",
+    "test": "vitest run",
+    "test:it": "vitest run --config vitest.it.config.ts"
+  },
+  "dependencies": {
+    "js-yaml": "4.1.1"
   },
   "devDependencies": {
-    "@aws-sdk/client-lambda": "^3.1001.0",
-    "@aws-sdk/client-s3": "^3.997.0",
+    "@aws-sdk/client-athena": "3.1040.0",
+    "@aws-sdk/client-cloudformation": "3.1040.0",
+    "@aws-sdk/client-lambda": "3.1020.0",
+    "@aws-sdk/client-organizations": "3.1040.0",
+    "@aws-sdk/client-s3": "3.1020.0",
+    "@aws-sdk/client-sfn": "3.1040.0",
+    "@aws-sdk/client-sts": "3.1040.0",
     "@types/aws-lambda": "^8.10.160",
+    "@types/js-yaml": "^4.0.9",
+    "aws-sdk-client-mock": "^4.0.0",
     "vitest": "^3.2.3"
   }
 }

--- a/source/lambda/routes/analyze-route.ts
+++ b/source/lambda/routes/analyze-route.ts
@@ -1,0 +1,224 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { SFNClient, StartExecutionCommand, DescribeExecutionCommand } from '@aws-sdk/client-sfn';
+import { OrganizationsClient, ListAccountsCommand } from '@aws-sdk/client-organizations';
+import { StatusCode } from '../constants/status-codes';
+import { HttpMethod } from '../constants/http-methods';
+import { EnvironmentKey, getEnv, getOptionalEnv } from '../constants/environment';
+import { Scope } from '../constants/scope';
+import { AnalyzerType, ExecutionStatus } from '../constants/analysis';
+import { logger } from '../util/logger';
+
+interface CloudTrailConfig {
+  bucket: string;
+  prefix?: string;
+  daysToScan?: number;
+}
+
+interface ResourceExplorerConfig {
+  // TODO: Add resource explorer specific config here
+  [key: string]: unknown;
+}
+
+interface CloudFormationConfig {
+  // TODO: Add cloudformation specific config here
+  [key: string]: unknown;
+}
+
+interface AnalyzerParams {
+  cloudtrail?: CloudTrailConfig;
+  resourceExplorer?: ResourceExplorerConfig;
+  cloudformation?: CloudFormationConfig;
+}
+
+interface AnalyzeRequest {
+  scope: Scope;
+  accountIds?: string[];
+  analyzers: AnalyzerType[];
+  analyzerParams?: AnalyzerParams;
+}
+
+/**
+ * Handles POST /analysis (start analysis) and GET /analysis (poll status).
+ *
+ * POST: Starts a Step Functions execution that orchestrates usage analyzers.
+ * For organization scope, discovers accounts via AWS Organizations.
+ *
+ * GET: Polls execution status via ?executionArn= query parameter.
+ * Returns RUNNING, SUCCEEDED (with results), or FAILED.
+ */
+export async function handleAnalyze(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  // Handle GET request - poll execution status
+  if (event.httpMethod === HttpMethod.GET) {
+    return await getAnalysisStatus(event);
+  }
+
+  // Handle POST request - start new analysis
+  try {
+    // The Usage Analysis stack is optional. When not deployed, the API Lambda's
+    // env vars for the state machine + analyzer Lambdas come through empty.
+    // Detect that explicitly and surface a friendly 503 instead of leaking
+    // a generic "Missing required environment variable: ..." 500 to the UI.
+    const stateMachineArn = getOptionalEnv(EnvironmentKey.ANALYSIS_STATE_MACHINE_ARN);
+    if (!stateMachineArn) {
+      return {
+        statusCode: StatusCode.SERVICE_UNAVAILABLE,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({
+          error: 'Usage Analysis is not enabled',
+          message:
+            'The Usage Analysis stack is not deployed. Re-run `npm run deploy -- --enable-usage-analysis` to enable personalization.',
+        }),
+      };
+    }
+
+    const body: AnalyzeRequest = JSON.parse(event.body || '{}');
+    const {
+      scope,
+      accountIds,
+      // 'resourceExplorer' is intentionally omitted from the default until
+      // its analyzer Lambda exists (see TODO in environment.ts). Callers can
+      // still opt in explicitly via analyzers in the request body.
+      analyzers = [AnalyzerType.CLOUDTRAIL, AnalyzerType.CLOUDFORMATION],
+      analyzerParams = {},
+    } = body;
+
+    if (!scope) {
+      return {
+        statusCode: StatusCode.BAD_REQUEST,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({ error: 'Missing required field: scope' }),
+      };
+    }
+
+    // Fall back to the deploy-time-configured bucket so UI callers don't have
+    // to re-supply it on every request.
+    const cloudTrailBucket =
+      analyzerParams.cloudtrail?.bucket || getOptionalEnv(EnvironmentKey.CONFIGURED_CLOUDTRAIL_BUCKET);
+
+    if (analyzers.includes(AnalyzerType.CLOUDTRAIL) && !cloudTrailBucket) {
+      return {
+        statusCode: StatusCode.BAD_REQUEST,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({ error: 'Missing required field: analyzerParams.cloudtrail.bucket' }),
+      };
+    }
+
+    const currentAccountId = event.requestContext.accountId;
+
+    // Determine accounts to analyze
+    const accounts =
+      scope === Scope.ORGANIZATION ? await discoverOrganizationAccounts() : accountIds || [currentAccountId];
+
+    // Start Step Function execution
+    const sfnClient = new SFNClient({});
+
+    const executionInput = {
+      scope,
+      accounts,
+      analyzers,
+      cloudTrailBucket,
+      cloudTrailPrefix: analyzerParams.cloudtrail?.prefix || 'AWSLogs/',
+      daysToScan: analyzerParams.cloudtrail?.daysToScan || 30,
+      websiteBucket: getEnv(EnvironmentKey.WEBSITE_BUCKET_NAME),
+      cloudtrailAnalyzerLambda: getEnv(EnvironmentKey.CLOUDTRAIL_ANALYZER_LAMBDA_NAME),
+      resourceExplorerAnalyzerLambda: getOptionalEnv(EnvironmentKey.RESOURCE_EXPLORER_ANALYZER_LAMBDA_NAME),
+      cloudformationAnalyzerLambda: getOptionalEnv(EnvironmentKey.CLOUDFORMATION_ANALYZER_LAMBDA_NAME),
+    };
+
+    const response = await sfnClient.send(
+      new StartExecutionCommand({
+        stateMachineArn,
+        input: JSON.stringify(executionInput),
+      }),
+    );
+
+    return {
+      statusCode: StatusCode.ACCEPTED,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({
+        executionArn: response.executionArn,
+        status: ExecutionStatus.RUNNING,
+        message: `${scope} analysis started`,
+      }),
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Analysis error', { error: String(error) });
+    return {
+      statusCode: StatusCode.INTERNAL_SERVER_ERROR,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ error: 'Analysis failed', message }),
+    };
+  }
+}
+
+/** Polls Step Functions execution status for a running analysis. */
+async function getAnalysisStatus(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  try {
+    const executionArn = event.queryStringParameters?.executionArn;
+
+    if (!executionArn) {
+      return {
+        statusCode: StatusCode.BAD_REQUEST,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({ error: 'Missing required query parameter: executionArn' }),
+      };
+    }
+
+    const sfnClient = new SFNClient({});
+    const execution = await sfnClient.send(new DescribeExecutionCommand({ executionArn }));
+
+    if (execution.status === ExecutionStatus.RUNNING) {
+      return {
+        statusCode: StatusCode.OK,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({ status: ExecutionStatus.RUNNING }),
+      };
+    }
+
+    if (execution.status === ExecutionStatus.SUCCEEDED) {
+      const results = execution.output ? JSON.parse(execution.output) : {};
+      return {
+        statusCode: StatusCode.OK,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify(results),
+      };
+    }
+
+    return {
+      statusCode: StatusCode.OK,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({
+        status: ExecutionStatus.FAILED,
+        error: execution.cause || execution.error || 'Unknown error',
+      }),
+    };
+  } catch (error: unknown) {
+    logger.error('Status check error', { error: String(error) });
+    return {
+      statusCode: StatusCode.INTERNAL_SERVER_ERROR,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({
+        status: ExecutionStatus.FAILED,
+        error: 'Failed to check analysis status',
+      }),
+    };
+  }
+}
+
+/** Discovers all active accounts in the AWS Organization. */
+async function discoverOrganizationAccounts(): Promise<string[]> {
+  const client = new OrganizationsClient({});
+  const accounts: string[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const response = await client.send(new ListAccountsCommand({ NextToken: nextToken }));
+    if (response.Accounts) {
+      accounts.push(...response.Accounts.filter(a => a.Status === 'ACTIVE').map(a => a.Id!));
+    }
+    nextToken = response.NextToken;
+  } while (nextToken);
+
+  return accounts;
+}

--- a/source/lambda/routes/usage-route.ts
+++ b/source/lambda/routes/usage-route.ts
@@ -1,0 +1,85 @@
+import { S3BucketClient } from '../services/s3-client';
+import { EnvironmentKey, getEnv } from '../constants/environment';
+import { Scope, VALID_SCOPES } from '../constants/scope';
+import { UsageFilter, VALID_USAGE_FILTERS } from '../constants/usage-filter';
+import { StatusCode } from '../constants/status-codes';
+import { logger } from '../util/logger';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+
+const corsHeaders = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+};
+
+/**
+ * GET /capabilities?usageFilter={mode}&scope={scope}
+ *
+ * Returns the pre-computed used-capabilities file for the requested
+ * (scope, filterMode) combination. The decorator Lambda writes these files
+ * as part of the Step Functions analysis workflow, so this handler just
+ * reads one S3 object and returns it verbatim.
+ *
+ * File layout:
+ *   data/json/used-capabilities-{scope}-{filterMode}.json
+ *
+ * Response shape:
+ *   { products: [...], apis: [...], cfnResources: [...], lastAnalyzedAt: "..." }
+ */
+export const getUsedCapabilities = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  try {
+    const usageFilter = (event.queryStringParameters?.usageFilter || UsageFilter.COMBINED) as UsageFilter;
+    const scope = (event.queryStringParameters?.scope || Scope.ACCOUNT) as Scope;
+
+    if (!VALID_USAGE_FILTERS.includes(usageFilter)) {
+      return {
+        statusCode: StatusCode.BAD_REQUEST,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          error: `Invalid usageFilter. Must be: ${VALID_USAGE_FILTERS.join(', ')}`,
+        }),
+      };
+    }
+
+    if (!VALID_SCOPES.includes(scope)) {
+      return {
+        statusCode: StatusCode.BAD_REQUEST,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          error: `Invalid scope. Must be: ${VALID_SCOPES.join(', ')}`,
+        }),
+      };
+    }
+
+    const s3 = new S3BucketClient(getEnv(EnvironmentKey.WEBSITE_BUCKET_NAME));
+    const key = `data/json/used-capabilities-${scope}-${usageFilter}.json`;
+
+    logger.info('Fetching used capabilities', { key });
+
+    let body: string;
+    try {
+      body = await s3.getObject(key);
+    } catch (e) {
+      logger.warn('Used capabilities file not found', { key, error: String(e) });
+      return {
+        statusCode: StatusCode.NOT_FOUND,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          error: `No usage data found for scope=${scope}. Run POST /analysis with scope=${scope} first.`,
+        }),
+      };
+    }
+
+    return {
+      statusCode: StatusCode.OK,
+      headers: corsHeaders,
+      body,
+    };
+  } catch (error) {
+    logger.error('Failed to get used capabilities', { error: String(error) });
+    return {
+      statusCode: StatusCode.INTERNAL_SERVER_ERROR,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: String(error) }),
+    };
+  }
+};

--- a/source/lambda/services/athena-client.ts
+++ b/source/lambda/services/athena-client.ts
@@ -1,0 +1,112 @@
+import {
+  AthenaClient,
+  StartQueryExecutionCommand,
+  GetQueryExecutionCommand,
+  GetQueryResultsCommand,
+} from '@aws-sdk/client-athena';
+import { AthenaQueryStatus } from '../constants/athena';
+import { cloudTrailUsageQuery } from './athena-queries';
+import { logger } from '../util/logger';
+
+interface AthenaQueryParams {
+  database: string;
+  query: string;
+  resultsLocation: string;
+}
+
+/**
+ * Executes an Athena query and waits for completion, paginating through all result pages.
+ * Polls query status every second, up to 12 minutes.
+ */
+export async function executeAthenaQuery(athena: AthenaClient, params: AthenaQueryParams): Promise<string[][]> {
+  // Start query
+  const { QueryExecutionId } = await athena.send(
+    new StartQueryExecutionCommand({
+      QueryString: params.query,
+      QueryExecutionContext: { Database: params.database },
+      ResultConfiguration: { OutputLocation: params.resultsLocation },
+    }),
+  );
+
+  if (!QueryExecutionId) {
+    throw new Error('Failed to start Athena query');
+  }
+
+  // Wait for completion
+  let status: string = AthenaQueryStatus.RUNNING;
+  let elapsedSeconds = 0;
+  const pollTimeoutSeconds = 720; // 12 minutes max
+  let queryExecution;
+
+  while (
+    (status === AthenaQueryStatus.RUNNING || status === AthenaQueryStatus.QUEUED) &&
+    elapsedSeconds < pollTimeoutSeconds
+  ) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const result = await athena.send(new GetQueryExecutionCommand({ QueryExecutionId }));
+
+    queryExecution = result.QueryExecution;
+    status = queryExecution?.Status?.State || AthenaQueryStatus.FAILED;
+    elapsedSeconds++;
+  }
+
+  if (status !== AthenaQueryStatus.SUCCEEDED) {
+    const failureReason = queryExecution?.Status?.StateChangeReason || 'Unknown reason';
+    logger.error('Athena query failed', {
+      status,
+      failureReason,
+      queryExecutionId: QueryExecutionId,
+    });
+    throw new Error(`Athena query failed with status: ${status}. Reason: ${failureReason}`);
+  }
+
+  // Get results, paginating through all pages
+  const allRows: string[][] = [];
+  let nextToken: string | undefined;
+  let isFirstPage = true;
+
+  do {
+    const response = await athena.send(
+      new GetQueryResultsCommand({
+        QueryExecutionId,
+        NextToken: nextToken,
+      }),
+    );
+
+    const rows = response.ResultSet?.Rows || [];
+
+    // Skip header row on the first page only
+    const dataRows = isFirstPage ? rows.slice(1) : rows;
+    isFirstPage = false;
+
+    for (const row of dataRows) {
+      allRows.push(row.Data?.map(col => col.VarCharValue || '') || []);
+    }
+
+    nextToken = response.NextToken;
+  } while (nextToken);
+
+  return allRows;
+}
+
+/**
+ * Queries CloudTrail logs for distinct service/API/region/account combinations.
+ * Filters to AwsApiCall events within the specified time window.
+ * daysToScan is sanitized to an integer between 1 and 365.
+ */
+export async function queryCloudTrailUsage(
+  athena: AthenaClient,
+  database: string,
+  tableName: string,
+  resultsLocation: string,
+  daysToScan: number = 30,
+): Promise<string[][]> {
+  const safeDays = Math.max(1, Math.min(Math.floor(daysToScan), 365));
+
+  return executeAthenaQuery(athena, {
+    database,
+    query: cloudTrailUsageQuery(database, tableName, safeDays),
+    resultsLocation,
+  });
+}

--- a/source/lambda/services/athena-queries.ts
+++ b/source/lambda/services/athena-queries.ts
@@ -1,0 +1,26 @@
+/**
+ * Athena SQL query templates for CloudTrail analysis.
+ * Kept separate from the client to keep the client slim.
+ *
+ * The Glue database and table are pre-provisioned by CDK (usage-analysis-stack).
+ * These templates are for runtime queries only.
+ */
+
+/**
+ * Queries CloudTrail logs for distinct service/API/region/account combinations.
+ * Filters to AwsApiCall events within the specified time window.
+ * @param safeDays - Pre-sanitized integer between 1 and 365.
+ */
+export function cloudTrailUsageQuery(database: string, tableName: string, safeDays: number): string {
+  return `
+    SELECT DISTINCT
+      eventsource,
+      eventname,
+      awsregion,
+      recipientaccountid
+    FROM ${database}.${tableName}
+    WHERE eventtime >= date_format(current_date - interval '${safeDays}' day, '%Y-%m-%d')
+      AND eventtype = 'AwsApiCall'
+    ORDER BY eventsource, eventname
+  `;
+}

--- a/source/lambda/services/cloudformation-client.test.ts
+++ b/source/lambda/services/cloudformation-client.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CloudFormationClient, GetTemplateCommand, ListStacksCommand } from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { ACTIVE_STACK_STATUSES } from '../constants/cloudformation';
+import { getProcessedTemplate, listActiveStacks } from './cloudformation-client';
+
+const cfnMock = mockClient(CloudFormationClient);
+
+describe('getProcessedTemplate', () => {
+  beforeEach(() => {
+    cfnMock.reset();
+  });
+
+  it('parses a JSON template body', async () => {
+    cfnMock.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: {
+          MyFunction: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'python3.11' } },
+        },
+      }),
+    });
+
+    const result = await getProcessedTemplate(new CloudFormationClient({}), 'stack-json');
+
+    expect(result).toEqual({
+      Resources: {
+        MyFunction: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'python3.11' } },
+      },
+    });
+  });
+
+  it('parses a YAML template body with CloudFormation intrinsic tags', async () => {
+    // Mirrors the real-world case: CloudFormation's GetTemplate returns
+    // whatever format was submitted. YAML templates use !Ref, !GetAtt,
+    // !Sub, etc. which standard YAML parsers reject.
+    const yamlTemplate = `
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: t3.medium
+      ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}'
+      SubnetId: !Ref MySubnet
+      SecurityGroupIds:
+        - !Ref MySecurityGroup
+      IamInstanceProfile: !GetAtt MyRole.Arn
+`;
+    cfnMock.on(GetTemplateCommand).resolves({ TemplateBody: yamlTemplate });
+
+    const result = await getProcessedTemplate(new CloudFormationClient({}), 'stack-yaml');
+
+    // Confirms the resource type + scalar properties survive the parse.
+    // Intrinsic tags are kept as opaque objects; downstream code only
+    // cares about scalar properties so this is enough.
+    const resources = result?.Resources as Record<string, { Type: string; Properties: Record<string, unknown> }>;
+    expect(resources.MyInstance.Type).toBe('AWS::EC2::Instance');
+    expect(resources.MyInstance.Properties.InstanceType).toBe('t3.medium');
+  });
+
+  it('parses YAML using newer intrinsic tags (!Length, !ToJsonString)', async () => {
+    // Locks in the recent addition of Length and ToJsonString to the
+    // intrinsic-tag list. If either is removed, this test fails before
+    // any production stack does.
+    const yamlTemplate = `
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: my-bucket
+      Tags:
+        - Key: ItemCount
+          Value: !Length [a, b, c]
+        - Key: Config
+          Value: !ToJsonString { foo: bar }
+`;
+    cfnMock.on(GetTemplateCommand).resolves({ TemplateBody: yamlTemplate });
+
+    const result = await getProcessedTemplate(new CloudFormationClient({}), 'stack-newer-tags');
+
+    const resources = result?.Resources as Record<string, { Type: string; Properties: Record<string, unknown> }>;
+    expect(resources.MyBucket.Type).toBe('AWS::S3::Bucket');
+    expect(resources.MyBucket.Properties.BucketName).toBe('my-bucket');
+  });
+
+  it('returns null when TemplateBody is absent', async () => {
+    cfnMock.on(GetTemplateCommand).resolves({});
+
+    const result = await getProcessedTemplate(new CloudFormationClient({}), 'stack-empty');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns an empty result for a fully empty TemplateBody string', async () => {
+    // CFN itself wouldn't return this, but the fallback path (YAML branch
+    // when body doesn't start with '{') gracefully handles it.
+    cfnMock.on(GetTemplateCommand).resolves({ TemplateBody: '' });
+
+    const result = await getProcessedTemplate(new CloudFormationClient({}), 'stack-blank');
+
+    // yaml.load('') returns null; downstream code's `if (!resources)` guard
+    // handles that. The function shouldn't throw.
+    expect(result).toBeNull();
+  });
+
+  it('returns null when JSON parse fails', async () => {
+    cfnMock.on(GetTemplateCommand).resolves({ TemplateBody: '{ broken: json' });
+
+    const result = await getProcessedTemplate(new CloudFormationClient({}), 'stack-bad');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('listActiveStacks', () => {
+  beforeEach(() => {
+    cfnMock.reset();
+  });
+
+  it('filters by ACTIVE_STACK_STATUSES', async () => {
+    cfnMock.on(ListStacksCommand).resolves({ StackSummaries: [] });
+
+    await listActiveStacks(new CloudFormationClient({}));
+
+    const calls = cfnMock.commandCalls(ListStacksCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input.StackStatusFilter).toEqual([...ACTIVE_STACK_STATUSES]);
+  });
+
+  it('paginates through multiple pages until NextToken is absent', async () => {
+    cfnMock
+      .on(ListStacksCommand)
+      .resolvesOnce({
+        StackSummaries: [{ StackName: 'stack-1', StackStatus: 'CREATE_COMPLETE', CreationTime: new Date() }],
+        NextToken: 'page-2',
+      })
+      .resolvesOnce({
+        StackSummaries: [
+          { StackName: 'stack-2', StackStatus: 'UPDATE_COMPLETE', CreationTime: new Date() },
+          { StackName: 'stack-3', StackStatus: 'CREATE_COMPLETE', CreationTime: new Date() },
+        ],
+        NextToken: 'page-3',
+      })
+      .resolvesOnce({
+        StackSummaries: [{ StackName: 'stack-4', StackStatus: 'CREATE_COMPLETE', CreationTime: new Date() }],
+        // No NextToken — terminates the loop
+      });
+
+    const stacks = await listActiveStacks(new CloudFormationClient({}));
+
+    expect(stacks.map(s => s.StackName)).toEqual(['stack-1', 'stack-2', 'stack-3', 'stack-4']);
+
+    // Three calls; second and third receive the prior NextToken.
+    const calls = cfnMock.commandCalls(ListStacksCommand);
+    expect(calls).toHaveLength(3);
+    expect(calls[0].args[0].input.NextToken).toBeUndefined();
+    expect(calls[1].args[0].input.NextToken).toBe('page-2');
+    expect(calls[2].args[0].input.NextToken).toBe('page-3');
+  });
+
+  it('returns [] when the API yields no stacks', async () => {
+    cfnMock.on(ListStacksCommand).resolves({ StackSummaries: [] });
+
+    const stacks = await listActiveStacks(new CloudFormationClient({}));
+
+    expect(stacks).toEqual([]);
+  });
+
+  it('handles a missing StackSummaries field as an empty page', async () => {
+    cfnMock.on(ListStacksCommand).resolves({});
+
+    const stacks = await listActiveStacks(new CloudFormationClient({}));
+
+    expect(stacks).toEqual([]);
+  });
+});

--- a/source/lambda/services/cloudformation-client.ts
+++ b/source/lambda/services/cloudformation-client.ts
@@ -1,0 +1,111 @@
+import {
+  CloudFormationClient,
+  ListStacksCommand,
+  GetTemplateCommand,
+  StackSummary,
+} from '@aws-sdk/client-cloudformation';
+import * as yaml from 'js-yaml';
+import { ACTIVE_STACK_STATUSES, TemplateStage } from '../constants/cloudformation';
+import { logger } from '../util/logger';
+
+/**
+ * CloudFormation YAML templates use custom intrinsic function tags (!Ref,
+ * !GetAtt, !Sub, etc.) that standard YAML parsers reject. This schema
+ * accepts them as opaque values so templates parse; downstream code only
+ * inspects resource types and scalar properties, so the intrinsic payloads
+ * don't need to be interpreted.
+ *
+ * Tags are constructed into the long-form `{ Fn::TAG: data }` shape so
+ * YAML and JSON inputs produce the same in-memory tree. Note `!Ref`'s
+ * canonical long form is `{ Ref: data }` (not `{ Fn::Ref: data }`); we
+ * normalize it to the prefixed form for consistency. The analyzer never
+ * inspects intrinsic payloads, so this asymmetry is invisible downstream.
+ */
+const CFN_INTRINSIC_TAGS = [
+  'Ref',
+  'GetAtt',
+  'Sub',
+  'Join',
+  'Select',
+  'Split',
+  'GetAZs',
+  'FindInMap',
+  'If',
+  'Equals',
+  'And',
+  'Or',
+  'Not',
+  'Base64',
+  'Cidr',
+  'ImportValue',
+  'Transform',
+  'Condition',
+  'Length',
+  'ToJsonString',
+];
+
+const CFN_YAML_SCHEMA = yaml.DEFAULT_SCHEMA.extend(
+  CFN_INTRINSIC_TAGS.flatMap(tag => [
+    new yaml.Type(`!${tag}`, { kind: 'scalar', construct: data => ({ [`Fn::${tag}`]: data }) }),
+    new yaml.Type(`!${tag}`, { kind: 'sequence', construct: data => ({ [`Fn::${tag}`]: data }) }),
+    new yaml.Type(`!${tag}`, { kind: 'mapping', construct: data => ({ [`Fn::${tag}`]: data }) }),
+  ]),
+);
+
+/**
+ * Parses a CloudFormation template body, which may be JSON or YAML.
+ * CloudFormation's GetTemplate returns the template in whatever format
+ * it was submitted, so analyzers must handle both.
+ */
+function parseTemplateBody(body: string): Record<string, unknown> {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith('{')) {
+    return JSON.parse(body);
+  }
+  return yaml.load(body, { schema: CFN_YAML_SCHEMA }) as Record<string, unknown>;
+}
+
+/**
+ * Lists all active CloudFormation stacks in the account.
+ * Paginates through all results.
+ */
+export async function listActiveStacks(client: CloudFormationClient): Promise<StackSummary[]> {
+  const stacks: StackSummary[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const response = await client.send(
+      new ListStacksCommand({
+        StackStatusFilter: [...ACTIVE_STACK_STATUSES],
+        NextToken: nextToken,
+      }),
+    );
+    stacks.push(...(response.StackSummaries || []));
+    nextToken = response.NextToken;
+  } while (nextToken);
+
+  return stacks;
+}
+
+/**
+ * Fetches the processed CloudFormation template for a stack.
+ * Returns the parsed template (from JSON or YAML), or null if it can't be retrieved.
+ */
+export async function getProcessedTemplate(
+  client: CloudFormationClient,
+  stackName: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await client.send(
+      new GetTemplateCommand({
+        StackName: stackName,
+        TemplateStage: TemplateStage.PROCESSED,
+      }),
+    );
+    if (!response.TemplateBody) return null;
+    return parseTemplateBody(response.TemplateBody);
+  } catch (e) {
+    logger.warn(`Failed to get template for stack ${stackName}`, { error: String(e) });
+    return null;
+  }
+}

--- a/source/lambda/services/s3-client.ts
+++ b/source/lambda/services/s3-client.ts
@@ -1,4 +1,4 @@
-import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, GetObjectCommand, PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 
 const client = new S3Client({});
 
@@ -27,6 +27,31 @@ export class S3BucketClient {
       );
     } catch (e) {
       throw new Error(`Failed to put s3://${this.bucket}/${path}: ${e}`);
+    }
+  }
+
+  /** Lists object keys under the given prefix. Paginates through all results. */
+  async listObjects(prefix: string): Promise<string[]> {
+    try {
+      const allKeys: string[] = [];
+      let continuationToken: string | undefined;
+
+      do {
+        const response = await client.send(
+          new ListObjectsV2Command({
+            Bucket: this.bucket,
+            Prefix: prefix,
+            ContinuationToken: continuationToken,
+          }),
+        );
+        const keys = (response.Contents || []).map(obj => obj.Key || '').filter(key => key !== '');
+        allKeys.push(...keys);
+        continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+      } while (continuationToken);
+
+      return allKeys;
+    } catch (e) {
+      throw new Error(`Failed to list s3://${this.bucket}/${prefix}: ${e}`);
     }
   }
 }

--- a/source/lambda/types/usage.ts
+++ b/source/lambda/types/usage.ts
@@ -1,0 +1,37 @@
+import type { RegionCode } from '@capability-insights/shared/types/capability/region';
+
+/**
+ * Shared types for usage analyzer outputs. These shapes are produced by the
+ * CloudTrail and CloudFormation analyzer Lambdas and consumed by downstream
+ * Lambdas (e.g., the usage decorator).
+ */
+
+/**
+ * CloudTrail usage data keyed by account ID, then service event source.
+ * Produced by the CloudTrail Analyzer Lambda via Athena queries.
+ */
+export interface CloudTrailUsage {
+  [accountId: string]: {
+    [eventSource: string]: {
+      apis: string[];
+      regionApis: Record<RegionCode, string[]>;
+    };
+  };
+}
+
+/**
+ * CloudFormation usage data as a flat list of resource records.
+ * Produced by the CloudFormation Analyzer Lambda.
+ */
+export interface CloudFormationUsage {
+  accountId: string;
+  region: RegionCode;
+  records: CloudFormationUsageRecord[];
+}
+
+export interface CloudFormationUsageRecord {
+  stackName: string;
+  serviceName: string;
+  resourceTypeName: string;
+  properties: Record<string, string[]>;
+}

--- a/source/lambda/usage-decorator.test.ts
+++ b/source/lambda/usage-decorator.test.ts
@@ -1,0 +1,827 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handler } from './usage-decorator';
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import { sdkStreamMixin } from '@smithy/util-stream';
+import { Readable } from 'stream';
+
+const s3Mock = mockClient(S3Client);
+
+const sampleProducts = [
+  {
+    productId: 'lambda-pid',
+    productName: 'AWS Lambda',
+    productType: 'SERVICE',
+    regionalAvailability: { 'us-east-1': 'Available' },
+    childProducts: [
+      {
+        productId: 'lambda-pid-layer',
+        productName: 'AWS Lambda Layers',
+        productType: 'FEATURE',
+        regionalAvailability: { 'us-east-1': 'Available' },
+      },
+    ],
+  },
+  {
+    productId: 's3-pid',
+    productName: 'Amazon S3',
+    productType: 'SERVICE',
+    regionalAvailability: { 'us-east-1': 'Available' },
+    childProducts: [],
+  },
+  {
+    productId: 'ec2-pid',
+    productName: 'Amazon EC2',
+    productType: 'SERVICE',
+    regionalAvailability: { 'us-east-1': 'Available' },
+    childProducts: [],
+  },
+  {
+    productId: 'unused-pid',
+    productName: 'Unused Service',
+    productType: 'SERVICE',
+    regionalAvailability: { 'us-east-1': 'Available' },
+    childProducts: [],
+  },
+];
+
+const sampleApis = [
+  {
+    sdkServiceName: 'Lambda',
+    productID: 'lambda-pid',
+    productName: 'AWS Lambda',
+    apis: [
+      { apiName: 'Lambda+Invoke', apiAction: 'Invoke' },
+      { apiName: 'Lambda+CreateFunction', apiAction: 'CreateFunction' },
+      { apiName: 'Lambda+DeleteFunction', apiAction: 'DeleteFunction' },
+    ],
+  },
+  {
+    sdkServiceName: 'S3',
+    productID: 's3-pid',
+    productName: 'Amazon S3',
+    apis: [
+      { apiName: 'S3+GetObject', apiAction: 'GetObject' },
+      { apiName: 'S3+PutObject', apiAction: 'PutObject' },
+    ],
+  },
+  {
+    sdkServiceName: 'EC2',
+    productID: 'ec2-pid',
+    productName: 'Amazon EC2',
+    apis: [{ apiName: 'EC2+DescribeInstances', apiAction: 'DescribeInstances' }],
+  },
+  {
+    sdkServiceName: 'Unused',
+    productID: 'unused-pid',
+    productName: 'Unused Service',
+    apis: [{ apiName: 'Unused+DoThing', apiAction: 'DoThing' }],
+  },
+];
+
+const sampleCfnResources = [
+  {
+    serviceName: 'Lambda',
+    resourceTypes: [
+      { resourceTypeName: 'Function', regionalAvailability: { 'us-east-1': 'Available' } },
+      { resourceTypeName: 'LayerVersion', regionalAvailability: { 'us-east-1': 'Available' } },
+    ],
+  },
+  {
+    serviceName: 'S3',
+    resourceTypes: [{ resourceTypeName: 'Bucket', regionalAvailability: { 'us-east-1': 'Available' } }],
+  },
+  {
+    serviceName: 'EC2',
+    resourceTypes: [{ resourceTypeName: 'Instance', regionalAvailability: { 'us-east-1': 'Available' } }],
+  },
+];
+
+const asStreamingBody = (obj: unknown) => sdkStreamMixin(Readable.from([JSON.stringify(obj)]));
+
+function mockCatalogFetches() {
+  s3Mock
+    .on(GetObjectCommand, { Key: 'data/json/products.json' })
+    .resolves({ Body: asStreamingBody(sampleProducts) as never })
+    .on(GetObjectCommand, { Key: 'data/json/apis.json' })
+    .resolves({ Body: asStreamingBody(sampleApis) as never })
+    .on(GetObjectCommand, { Key: 'data/json/cfn_resources.json' })
+    .resolves({ Body: asStreamingBody(sampleCfnResources) as never });
+}
+
+interface CapturedBody {
+  products: Array<{ productId: string; childProducts?: Array<{ productId: string }> }>;
+  apis: Array<{ sdkServiceName: string; apis: Array<{ apiAction: string }> }>;
+  cfnResources: Array<{
+    serviceName: string;
+    resourceTypes: Array<{
+      resourceTypeName: string;
+      usage?: { stacks: string[]; properties: Record<string, string[]>; count: number };
+    }>;
+  }>;
+  lastAnalyzedAt: string;
+}
+
+function capturedPut(key: string): CapturedBody {
+  const calls = s3Mock.commandCalls(PutObjectCommand);
+  const call = calls.find(c => c.args[0].input.Key === key);
+  if (!call) throw new Error(`No PutObject for ${key}`);
+  return JSON.parse(call.args[0].input.Body as string) as CapturedBody;
+}
+
+describe('usage-decorator', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+    mockCatalogFetches();
+    s3Mock.on(PutObjectCommand).resolves({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('input validation', () => {
+    it('throws when websiteBucket is missing', async () => {
+      await expect(handler({})).rejects.toThrow('websiteBucket');
+    });
+  });
+
+  describe('file layout', () => {
+    it('writes three files for account scope (default)', async () => {
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, null] });
+
+      const puts = s3Mock.commandCalls(PutObjectCommand);
+      const keys = puts.map(p => p.args[0].input.Key).sort();
+      expect(keys).toEqual([
+        'data/json/used-capabilities-account-active_usage.json',
+        'data/json/used-capabilities-account-combined.json',
+        'data/json/used-capabilities-account-deployed.json',
+      ]);
+    });
+
+    it('writes three files for organization scope', async () => {
+      await handler({ websiteBucket: 'test-bucket', scope: 'organization', parallelResults: [{}, null] });
+
+      const puts = s3Mock.commandCalls(PutObjectCommand);
+      const keys = puts.map(p => p.args[0].input.Key).sort();
+      expect(keys).toEqual([
+        'data/json/used-capabilities-organization-active_usage.json',
+        'data/json/used-capabilities-organization-combined.json',
+        'data/json/used-capabilities-organization-deployed.json',
+      ]);
+    });
+
+    it('each file has the expected top-level shape', async () => {
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, null] });
+
+      for (const mode of ['deployed', 'active_usage', 'combined']) {
+        const body = capturedPut(`data/json/used-capabilities-account-${mode}.json`);
+        expect(body).toHaveProperty('products');
+        expect(body).toHaveProperty('apis');
+        expect(body).toHaveProperty('cfnResources');
+        expect(body).toHaveProperty('lastAnalyzedAt');
+      }
+    });
+  });
+
+  describe('filter mode: deployed', () => {
+    it('populates products from CloudFormation matches only', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'Lambda', resourceTypeName: 'Function', properties: {} }],
+      };
+      const cloudTrailUsage = {
+        '123456789012': {
+          's3.amazonaws.com': { apis: ['GetObject'], regionApis: { 'us-east-1': ['GetObject'] } },
+        },
+      };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      expect(body.products.map(p => p.productId).sort()).toEqual(['lambda-pid']);
+    });
+
+    it('has empty apis array', async () => {
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      expect(body.apis).toEqual([]);
+    });
+
+    it('populates cfnResources with usage enrichment', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [
+          {
+            stackName: 'AppStack',
+            serviceName: 'Lambda',
+            resourceTypeName: 'Function',
+            properties: { Runtime: ['python3.11'], MemorySize: ['256'] },
+          },
+          {
+            stackName: 'ApiStack',
+            serviceName: 'Lambda',
+            resourceTypeName: 'Function',
+            properties: { Runtime: ['nodejs20.x'] },
+          },
+        ],
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      const lambda = body.cfnResources.find(r => r.serviceName === 'Lambda');
+      const fn = lambda?.resourceTypes.find(rt => rt.resourceTypeName === 'Function');
+      expect(fn?.usage?.stacks.sort()).toEqual(['ApiStack', 'AppStack']);
+      expect(fn?.usage?.count).toBe(2);
+      expect(fn?.usage?.properties.Runtime?.sort()).toEqual(['nodejs20.x', 'python3.11']);
+      expect(fn?.usage?.properties.MemorySize).toEqual(['256']);
+    });
+
+    it('narrows resourceProperties.resourceConfigurations to deployed values only', async () => {
+      // Master cfn_resources.json lists all possible InstanceType configurations
+      // for EC2::Instance. The decorator should narrow this to only the values
+      // actually deployed (t3.medium), dropping c5.large / m5.xlarge / etc.
+      const richCfnResources = [
+        {
+          serviceName: 'EC2',
+          resourceTypes: [
+            {
+              resourceTypeName: 'Instance',
+              regionalAvailability: { 'us-east-1': 'Available' },
+              resourceProperties: [
+                {
+                  resourcePropertyName: 'InstanceType',
+                  resourceConfigurations: [
+                    { resourceConfigurationName: 't3.medium', regionalAvailability: {} },
+                    { resourceConfigurationName: 'c5.large', regionalAvailability: {} },
+                    { resourceConfigurationName: 'm5.xlarge', regionalAvailability: {} },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      s3Mock.reset();
+      s3Mock
+        .on(GetObjectCommand, { Key: 'data/json/products.json' })
+        .resolves({ Body: asStreamingBody(sampleProducts) as never })
+        .on(GetObjectCommand, { Key: 'data/json/apis.json' })
+        .resolves({ Body: asStreamingBody(sampleApis) as never })
+        .on(GetObjectCommand, { Key: 'data/json/cfn_resources.json' })
+        .resolves({ Body: asStreamingBody(richCfnResources) as never })
+        .on(PutObjectCommand)
+        .resolves({});
+
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [
+          {
+            stackName: 'AppStack',
+            serviceName: 'EC2',
+            resourceTypeName: 'Instance',
+            properties: { InstanceType: ['t3.medium'] },
+          },
+        ],
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      const ec2 = body.cfnResources.find(r => r.serviceName === 'EC2');
+      const instance = ec2?.resourceTypes.find(rt => rt.resourceTypeName === 'Instance') as {
+        resourceProperties?: Array<{
+          resourcePropertyName: string;
+          resourceConfigurations: Array<{ resourceConfigurationName: string }>;
+        }>;
+      };
+      expect(instance?.resourceProperties).toHaveLength(1);
+      const instanceTypeProp = instance?.resourceProperties?.[0];
+      expect(instanceTypeProp?.resourcePropertyName).toBe('InstanceType');
+      expect(instanceTypeProp?.resourceConfigurations.map(c => c.resourceConfigurationName)).toEqual(['t3.medium']);
+    });
+
+    it('attributes configuration values to the stacks that contributed them', async () => {
+      const richCfnResources = [
+        {
+          serviceName: 'EC2',
+          resourceTypes: [
+            {
+              resourceTypeName: 'Instance',
+              regionalAvailability: { 'us-east-1': 'Available' },
+              resourceProperties: [
+                {
+                  resourcePropertyName: 'InstanceType',
+                  resourceConfigurations: [
+                    { resourceConfigurationName: 't3.medium', regionalAvailability: {} },
+                    { resourceConfigurationName: 't3.micro', regionalAvailability: {} },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      s3Mock.reset();
+      s3Mock
+        .on(GetObjectCommand, { Key: 'data/json/products.json' })
+        .resolves({ Body: asStreamingBody(sampleProducts) as never })
+        .on(GetObjectCommand, { Key: 'data/json/apis.json' })
+        .resolves({ Body: asStreamingBody(sampleApis) as never })
+        .on(GetObjectCommand, { Key: 'data/json/cfn_resources.json' })
+        .resolves({ Body: asStreamingBody(richCfnResources) as never })
+        .on(PutObjectCommand)
+        .resolves({});
+
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [
+          {
+            stackName: 'AppStack',
+            serviceName: 'EC2',
+            resourceTypeName: 'Instance',
+            properties: { InstanceType: ['t3.medium'] },
+          },
+          {
+            stackName: 'SampleStack',
+            serviceName: 'EC2',
+            resourceTypeName: 'Instance',
+            properties: { InstanceType: ['t3.micro'] },
+          },
+        ],
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      const ec2 = body.cfnResources.find(r => r.serviceName === 'EC2');
+      const instance = ec2?.resourceTypes.find(rt => rt.resourceTypeName === 'Instance') as {
+        resourceProperties?: Array<{
+          resourceConfigurations: Array<{ resourceConfigurationName: string; stacks?: string[] }>;
+        }>;
+      };
+      const configs = instance?.resourceProperties?.[0].resourceConfigurations ?? [];
+      const t3Medium = configs.find(c => c.resourceConfigurationName === 't3.medium');
+      const t3Micro = configs.find(c => c.resourceConfigurationName === 't3.micro');
+      expect(t3Medium?.stacks).toEqual(['AppStack']);
+      expect(t3Micro?.stacks).toEqual(['SampleStack']);
+    });
+
+    it('keeps the resource-type-level usage.stacks consistent with per-configuration stacks', async () => {
+      // Layer 1 (resource-type usage.stacks) must equal the union of Layer 2 (per-config stacks[]).
+      // They share the same source map; drift would indicate a decorator bug.
+      const richCfnResources = [
+        {
+          serviceName: 'EC2',
+          resourceTypes: [
+            {
+              resourceTypeName: 'Instance',
+              regionalAvailability: { 'us-east-1': 'Available' },
+              resourceProperties: [
+                {
+                  resourcePropertyName: 'InstanceType',
+                  resourceConfigurations: [
+                    { resourceConfigurationName: 't3.medium', regionalAvailability: {} },
+                    { resourceConfigurationName: 't3.micro', regionalAvailability: {} },
+                    { resourceConfigurationName: 'm5.large', regionalAvailability: {} },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      s3Mock.reset();
+      s3Mock
+        .on(GetObjectCommand, { Key: 'data/json/products.json' })
+        .resolves({ Body: asStreamingBody(sampleProducts) as never })
+        .on(GetObjectCommand, { Key: 'data/json/apis.json' })
+        .resolves({ Body: asStreamingBody(sampleApis) as never })
+        .on(GetObjectCommand, { Key: 'data/json/cfn_resources.json' })
+        .resolves({ Body: asStreamingBody(richCfnResources) as never })
+        .on(PutObjectCommand)
+        .resolves({});
+
+      // Three stacks, partial overlap. Stack-A: t3.medium + t3.micro. Stack-B: t3.medium. Stack-C: m5.large.
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [
+          {
+            stackName: 'Stack-A',
+            serviceName: 'EC2',
+            resourceTypeName: 'Instance',
+            properties: { InstanceType: ['t3.medium', 't3.micro'] },
+          },
+          {
+            stackName: 'Stack-B',
+            serviceName: 'EC2',
+            resourceTypeName: 'Instance',
+            properties: { InstanceType: ['t3.medium'] },
+          },
+          {
+            stackName: 'Stack-C',
+            serviceName: 'EC2',
+            resourceTypeName: 'Instance',
+            properties: { InstanceType: ['m5.large'] },
+          },
+        ],
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      const ec2 = body.cfnResources.find(r => r.serviceName === 'EC2');
+      const instance = ec2?.resourceTypes.find(rt => rt.resourceTypeName === 'Instance') as {
+        usage?: { stacks: string[]; count: number };
+        resourceProperties?: Array<{
+          resourceConfigurations: Array<{ resourceConfigurationName: string; stacks?: string[] }>;
+        }>;
+      };
+
+      const layer1Stacks = new Set(instance?.usage?.stacks ?? []);
+      expect(layer1Stacks).toEqual(new Set(['Stack-A', 'Stack-B', 'Stack-C']));
+      expect(instance?.usage?.count).toBe(3);
+
+      const configs = instance?.resourceProperties?.[0].resourceConfigurations ?? [];
+      const byName = Object.fromEntries(configs.map(c => [c.resourceConfigurationName, c.stacks ?? []]));
+      expect(new Set(byName['t3.medium'])).toEqual(new Set(['Stack-A', 'Stack-B']));
+      expect(new Set(byName['t3.micro'])).toEqual(new Set(['Stack-A']));
+      expect(new Set(byName['m5.large'])).toEqual(new Set(['Stack-C']));
+
+      const layer2Union = new Set(configs.flatMap(c => c.stacks ?? []));
+      expect(layer2Union).toEqual(layer1Stacks);
+    });
+
+    it('drops resource types and services with no CFN usage', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'Lambda', resourceTypeName: 'Function', properties: {} }],
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-deployed.json');
+      // Only Lambda::Function should remain. S3::Bucket, EC2::Instance, Lambda::LayerVersion should be absent.
+      expect(body.cfnResources).toHaveLength(1);
+      expect(body.cfnResources[0].serviceName).toBe('Lambda');
+      expect(body.cfnResources[0].resourceTypes).toHaveLength(1);
+      expect(body.cfnResources[0].resourceTypes[0].resourceTypeName).toBe('Function');
+    });
+  });
+
+  describe('filter mode: active_usage', () => {
+    it('populates products from CloudTrail matches only', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'EC2', resourceTypeName: 'Instance', properties: {} }],
+      };
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(body.products.map(p => p.productId)).toEqual(['lambda-pid']);
+    });
+
+    it('scopes each service apis[] to only the called APIs', async () => {
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': {
+            apis: ['Invoke', 'CreateFunction'],
+            regionApis: { 'us-east-1': ['Invoke', 'CreateFunction'] },
+          },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(body.apis).toHaveLength(1);
+      const lambdaApi = body.apis[0];
+      expect(lambdaApi.sdkServiceName).toBe('Lambda');
+      // DeleteFunction was not called, so it should NOT appear
+      expect(lambdaApi.apis.map(a => a.apiAction).sort()).toEqual(['CreateFunction', 'Invoke']);
+    });
+
+    it('has empty cfnResources array', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'Lambda', resourceTypeName: 'Function', properties: {} }],
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [{}, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(body.cfnResources).toEqual([]);
+    });
+
+    it('drops services entirely when no APIs were called', async () => {
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      // S3, EC2, Unused should be absent since no CloudTrail calls for them
+      const sdkServiceNames = body.apis.map(a => a.sdkServiceName);
+      expect(sdkServiceNames).toEqual(['Lambda']);
+    });
+  });
+
+  describe('filter mode: combined', () => {
+    it('populates products from the union of both sources', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'EC2', resourceTypeName: 'Instance', properties: {} }],
+      };
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-combined.json');
+      expect(body.products.map(p => p.productId).sort()).toEqual(['ec2-pid', 'lambda-pid']);
+    });
+
+    it('dedupes products across sources', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'Lambda', resourceTypeName: 'Function', properties: {} }],
+      };
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-combined.json');
+      // Lambda is in both — should appear exactly once
+      const pids = body.products.map(p => p.productId);
+      expect(pids).toEqual(['lambda-pid']);
+    });
+
+    it('includes both apis (from CloudTrail) and cfnResources (from CloudFormation)', async () => {
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'EC2', resourceTypeName: 'Instance', properties: {} }],
+      };
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, cloudFormationUsage] });
+
+      const body = capturedPut('data/json/used-capabilities-account-combined.json');
+      expect(body.apis.map(a => a.sdkServiceName)).toEqual(['Lambda']);
+      expect(body.cfnResources.map(c => c.serviceName)).toEqual(['EC2']);
+    });
+  });
+
+  describe('child products', () => {
+    it('includes all child products for matched services by default (include-all-features on)', async () => {
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      const lambda = body.products.find(p => p.productId === 'lambda-pid');
+      // Default keeps all features even when only the parent was observed.
+      expect(lambda?.childProducts).toEqual([expect.objectContaining({ productId: 'lambda-pid-layer' })]);
+    });
+
+    it('narrows child products to observed features when INCLUDE_ALL_FEATURES_PER_SERVICE is "false"', async () => {
+      vi.stubEnv('INCLUDE_ALL_FEATURES_PER_SERVICE', 'false');
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      const lambda = body.products.find(p => p.productId === 'lambda-pid');
+      // With the flag off, Lambda Layer is dropped because it wasn't in usage.
+      expect(lambda?.childProducts).toEqual([]);
+    });
+
+    it('treats INCLUDE_ALL_FEATURES_PER_SERVICE case-insensitively ("FALSE" disables it)', async () => {
+      vi.stubEnv('INCLUDE_ALL_FEATURES_PER_SERVICE', 'FALSE');
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      const lambda = body.products.find(p => p.productId === 'lambda-pid');
+      expect(lambda?.childProducts).toEqual([]);
+    });
+
+    it('treats any non-"false" value as enabled (e.g., "no", "0", "truthy")', async () => {
+      vi.stubEnv('INCLUDE_ALL_FEATURES_PER_SERVICE', 'no');
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      const lambda = body.products.find(p => p.productId === 'lambda-pid');
+      expect(lambda?.childProducts).toEqual([expect.objectContaining({ productId: 'lambda-pid-layer' })]);
+    });
+  });
+
+  describe('graceful degradation', () => {
+    it('handles failed CloudTrail branch', async () => {
+      const failedBranch = { analyzer: 'cloudtrail', status: 'failed', error: 'boom' };
+      const cloudFormationUsage = {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        records: [{ stackName: 'AppStack', serviceName: 'Lambda', resourceTypeName: 'Function', properties: {} }],
+      };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [failedBranch, cloudFormationUsage] });
+
+      const deployed = capturedPut('data/json/used-capabilities-account-deployed.json');
+      expect(deployed.products).toHaveLength(1);
+      expect(deployed.cfnResources).toHaveLength(1);
+
+      const activeUsage = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(activeUsage.products).toEqual([]);
+      expect(activeUsage.apis).toEqual([]);
+    });
+
+    it('handles failed CloudFormation branch', async () => {
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      const failedBranch = { analyzer: 'cloudformation', status: 'failed', error: 'boom' };
+
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, failedBranch] });
+
+      const deployed = capturedPut('data/json/used-capabilities-account-deployed.json');
+      expect(deployed.products).toEqual([]);
+      expect(deployed.cfnResources).toEqual([]);
+
+      const activeUsage = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(activeUsage.products).toHaveLength(1);
+      expect(activeUsage.apis).toHaveLength(1);
+    });
+
+    it('handles missing parallelResults entirely', async () => {
+      await handler({ websiteBucket: 'test-bucket' });
+
+      for (const mode of ['deployed', 'active_usage', 'combined']) {
+        const body = capturedPut(`data/json/used-capabilities-account-${mode}.json`);
+        expect(body.products).toEqual([]);
+        expect(body.apis).toEqual([]);
+        expect(body.cfnResources).toEqual([]);
+      }
+    });
+  });
+
+  describe('sdk service name normalization', () => {
+    it('strips .amazonaws.com suffix from CloudTrail eventSources', async () => {
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(body.products.map(p => p.productId)).toEqual(['lambda-pid']);
+    });
+
+    it('handles collapsed sdkServiceName variants (with spaces/dashes)', async () => {
+      // Add an ApiService with a spaced name to verify collapsed lookup works
+      const apisWithSpace = [
+        ...sampleApis,
+        {
+          sdkServiceName: 'API Gateway',
+          productID: 'apigw-pid',
+          productName: 'Amazon API Gateway',
+          apis: [{ apiName: 'APIGateway+CreateApi', apiAction: 'CreateApi' }],
+        },
+      ];
+      s3Mock.reset();
+      s3Mock
+        .on(GetObjectCommand, { Key: 'data/json/products.json' })
+        .resolves({ Body: asStreamingBody(sampleProducts) as never })
+        .on(GetObjectCommand, { Key: 'data/json/apis.json' })
+        .resolves({ Body: asStreamingBody(apisWithSpace) as never })
+        .on(GetObjectCommand, { Key: 'data/json/cfn_resources.json' })
+        .resolves({ Body: asStreamingBody(sampleCfnResources) as never })
+        .on(PutObjectCommand)
+        .resolves({});
+
+      const cloudTrailUsage = {
+        '123456789012': {
+          // CloudTrail uses "apigateway" (no space) — should still match "API Gateway"
+          'apigateway.amazonaws.com': { apis: ['CreateApi'], regionApis: { 'us-east-1': ['CreateApi'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(body.apis.map(a => a.sdkServiceName)).toEqual(['API Gateway']);
+    });
+
+    it('resolves CloudTrail-specific event sources via the alias map', async () => {
+      // monitoring.amazonaws.com is the CloudTrail source for CloudWatch
+      const apisWithCloudWatch = [
+        {
+          sdkServiceName: 'CloudWatch',
+          productID: 'cloudwatch-pid',
+          productName: 'Amazon CloudWatch',
+          apis: [{ apiName: 'CloudWatch+GetMetricData', apiAction: 'GetMetricData' }],
+        },
+      ];
+      const productsWithCloudWatch = [
+        {
+          productId: 'cloudwatch-pid',
+          productName: 'Amazon CloudWatch',
+          productType: 'SERVICE',
+          regionalAvailability: { 'us-east-1': 'Available' },
+          childProducts: [],
+        },
+      ];
+
+      s3Mock.reset();
+      s3Mock
+        .on(GetObjectCommand, { Key: 'data/json/products.json' })
+        .resolves({ Body: asStreamingBody(productsWithCloudWatch) as never })
+        .on(GetObjectCommand, { Key: 'data/json/apis.json' })
+        .resolves({ Body: asStreamingBody(apisWithCloudWatch) as never })
+        .on(GetObjectCommand, { Key: 'data/json/cfn_resources.json' })
+        .resolves({ Body: asStreamingBody([]) as never })
+        .on(PutObjectCommand)
+        .resolves({});
+
+      const cloudTrailUsage = {
+        '123456789012': {
+          'monitoring.amazonaws.com': {
+            apis: ['GetMetricData'],
+            regionApis: { 'us-east-1': ['GetMetricData'] },
+          },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      // Without the alias map this would not resolve because the cleaned
+      // event source ("monitoring") doesn't match the sdkServiceName ("cloudwatch").
+      expect(body.products.map(p => p.productId)).toEqual(['cloudwatch-pid']);
+      expect(body.apis.map(a => a.sdkServiceName)).toEqual(['CloudWatch']);
+    });
+
+    it('prefers direct sdkServiceName match over alias map', async () => {
+      // If CloudTrail source matches an sdkServiceName directly (e.g., lambda),
+      // it should not consult the alias map.
+      const cloudTrailUsage = {
+        '123456789012': {
+          'lambda.amazonaws.com': { apis: ['Invoke'], regionApis: { 'us-east-1': ['Invoke'] } },
+        },
+      };
+      await handler({ websiteBucket: 'test-bucket', parallelResults: [cloudTrailUsage, null] });
+
+      const body = capturedPut('data/json/used-capabilities-account-active_usage.json');
+      expect(body.products.map(p => p.productId)).toEqual(['lambda-pid']);
+    });
+  });
+});

--- a/source/lambda/usage-decorator.ts
+++ b/source/lambda/usage-decorator.ts
@@ -1,0 +1,368 @@
+import type { ApiService } from '@capability-insights/shared/types/capability/api';
+import type {
+  CfnResource,
+  EnrichedCfnResource,
+  EnrichedCfnResourceType,
+} from '@capability-insights/shared/types/capability/cfn';
+import type { Product } from '@capability-insights/shared/types/capability/product';
+import type { UsedCapabilities } from '@capability-insights/shared/types/used-capabilities';
+import { CLOUDTRAIL_SERVICE_ALIASES } from './constants/cloudtrail-service-aliases';
+import { EnvironmentKey, getOptionalEnv } from './constants/environment';
+import { Scope } from './constants/scope';
+import { UsageFilter, VALID_USAGE_FILTERS } from './constants/usage-filter';
+import { S3BucketClient } from './services/s3-client';
+import type { CloudFormationUsage, CloudTrailUsage } from './types/usage';
+import { logger } from './util/logger';
+
+type ParallelAnalyzerOutput = Array<unknown>;
+
+interface DecoratorEvent {
+  websiteBucket?: string;
+  scope?: Scope;
+  parallelResults?: ParallelAnalyzerOutput;
+}
+
+/**
+ * Decorates analyzer usage data with regional availability from the master
+ * capability catalogs, producing pre-computed "used-capabilities" files —
+ * one per (scope, filterMode) pair.
+ *
+ * Six possible outputs:
+ *   data/json/used-capabilities-{account|organization}-{deployed|active_usage|combined}.json
+ *
+ * Each file has the shape:
+ *   { products, apis, cfnResources, lastAnalyzedAt }
+ *
+ * The API Lambda reads one file per /capabilities request based on the
+ * requested scope + usageFilter, avoiding per-request computation.
+ */
+export const handler = async (event: DecoratorEvent): Promise<Record<UsageFilter, number>> => {
+  const websiteBucket = event.websiteBucket;
+  if (!websiteBucket) {
+    throw new Error('websiteBucket is required');
+  }
+
+  const scope: Scope = event.scope === Scope.ORGANIZATION ? Scope.ORGANIZATION : Scope.ACCOUNT;
+  const [cloudTrailResult, cloudFormationResult] = event.parallelResults ?? [];
+  const cloudTrailUsage = isCloudTrailUsage(cloudTrailResult) ? cloudTrailResult : {};
+  const cloudFormationUsage = isCloudFormationUsage(cloudFormationResult) ? cloudFormationResult : null;
+
+  // When true (default), each service kept in the personalized view keeps
+  // all its childProducts (features) from the master catalog, even those
+  // not individually observed in usage data. When false, childProducts are
+  // narrowed to only the features directly observed.
+  const includeAllFeaturesPerService =
+    getOptionalEnv(EnvironmentKey.INCLUDE_ALL_FEATURES_PER_SERVICE, 'true').toLowerCase() !== 'false';
+
+  logger.info('Starting usage decorator', {
+    scope,
+    hasCloudTrail: Object.keys(cloudTrailUsage).length > 0,
+    hasCloudFormation: cloudFormationUsage !== null,
+    includeAllFeaturesPerService,
+  });
+
+  const s3 = new S3BucketClient(websiteBucket);
+
+  // Load master catalogs
+  const [productsRaw, apisRaw, cfnResourcesRaw] = await Promise.all([
+    s3.getObject('data/json/products.json'),
+    s3.getObject('data/json/apis.json'),
+    s3.getObject('data/json/cfn_resources.json'),
+  ]);
+  const products = JSON.parse(productsRaw) as Product[];
+  const apis = JSON.parse(apisRaw) as ApiService[];
+  const cfnResources = JSON.parse(cfnResourcesRaw) as CfnResource[];
+
+  // Build lookup maps used across filter modes
+  const sdkToProductId = buildSdkToProductIdMap(apis);
+
+  const lastAnalyzedAt = new Date().toISOString();
+
+  // Compute each filter mode's view
+  const views: Record<UsageFilter, UsedCapabilities> = {
+    [UsageFilter.DEPLOYED]: buildView(UsageFilter.DEPLOYED, {
+      cloudTrailUsage,
+      cloudFormationUsage,
+      products,
+      apis,
+      cfnResources,
+      sdkToProductId,
+      lastAnalyzedAt,
+      includeAllFeaturesPerService,
+    }),
+    [UsageFilter.ACTIVE_USAGE]: buildView(UsageFilter.ACTIVE_USAGE, {
+      cloudTrailUsage,
+      cloudFormationUsage,
+      products,
+      apis,
+      cfnResources,
+      sdkToProductId,
+      lastAnalyzedAt,
+      includeAllFeaturesPerService,
+    }),
+    [UsageFilter.COMBINED]: buildView(UsageFilter.COMBINED, {
+      cloudTrailUsage,
+      cloudFormationUsage,
+      products,
+      apis,
+      cfnResources,
+      sdkToProductId,
+      lastAnalyzedAt,
+      includeAllFeaturesPerService,
+    }),
+  };
+
+  // Write all files in parallel
+  await Promise.all(
+    VALID_USAGE_FILTERS.map(mode => {
+      const key = `data/json/used-capabilities-${scope}-${mode}.json`;
+      return s3.putObject(key, JSON.stringify(views[mode]), 'application/json');
+    }),
+  );
+
+  const counts: Record<UsageFilter, number> = {
+    [UsageFilter.DEPLOYED]: views[UsageFilter.DEPLOYED].products.length,
+    [UsageFilter.ACTIVE_USAGE]: views[UsageFilter.ACTIVE_USAGE].products.length,
+    [UsageFilter.COMBINED]: views[UsageFilter.COMBINED].products.length,
+  };
+
+  logger.info('Decoration complete', { scope, counts });
+  return counts;
+};
+
+interface BuildViewContext {
+  cloudTrailUsage: CloudTrailUsage;
+  cloudFormationUsage: CloudFormationUsage | null;
+  products: Product[];
+  apis: ApiService[];
+  cfnResources: CfnResource[];
+  sdkToProductId: Map<string, string>;
+  lastAnalyzedAt: string;
+  includeAllFeaturesPerService: boolean;
+}
+
+/**
+ * Computes the used-capabilities view for a single filter mode.
+ *
+ * Filter semantics:
+ * - deployed: CloudFormation is the authority. products from CFN matches;
+ *   apis empty; cfnResources from CFN with usage enrichment.
+ * - active_usage: CloudTrail is the authority. products from CloudTrail
+ *   matches; apis scoped to called APIs; cfnResources empty.
+ * - combined: union of both sources for products; apis from CloudTrail;
+ *   cfnResources from CloudFormation with enrichment.
+ */
+function buildView(mode: UsageFilter, ctx: BuildViewContext): UsedCapabilities {
+  const {
+    cloudTrailUsage,
+    cloudFormationUsage,
+    products,
+    apis,
+    cfnResources,
+    sdkToProductId,
+    lastAnalyzedAt,
+    includeAllFeaturesPerService,
+  } = ctx;
+
+  // CloudTrail-detected productIds + the set of called API names per service
+  const ctProductIds = new Set<string>();
+  const calledApisBySdkService = new Map<string, Set<string>>();
+  for (const services of Object.values(cloudTrailUsage)) {
+    for (const [eventSource, data] of Object.entries(services)) {
+      const cleaned = eventSource.replace('.amazonaws.com', '').toLowerCase();
+      // Try the cleaned slug first. If that misses, fall back to the
+      // alias map (bridges CloudTrail-style names to SDK names).
+      const resolvedSdkName = sdkToProductId.has(cleaned) ? cleaned : CLOUDTRAIL_SERVICE_ALIASES[cleaned];
+      const pid = resolvedSdkName ? sdkToProductId.get(resolvedSdkName) : undefined;
+      if (!pid || !resolvedSdkName) continue;
+      ctProductIds.add(pid);
+
+      // Track which API names were called, keyed by the resolved SDK name
+      // so filterApisScopedToCalled can match against apis.json entries.
+      if (!calledApisBySdkService.has(resolvedSdkName)) {
+        calledApisBySdkService.set(resolvedSdkName, new Set());
+      }
+      const apiSet = calledApisBySdkService.get(resolvedSdkName)!;
+      for (const api of data.apis) apiSet.add(api);
+    }
+  }
+
+  // CloudFormation-detected productIds + per-resource-type usage
+  const cfProductIds = new Set<string>();
+  // Per-resource-type aggregation. `properties` tracks which stacks
+  // contributed each (property, value) pair, so the UI can filter leaf
+  // configurations by stack ("show only t3.medium from test-assets-*,
+  // not t3.micro from the sample env").
+  const cfUsageByFqn = new Map<string, { stacks: Set<string>; properties: Record<string, Map<string, Set<string>>> }>();
+  if (cloudFormationUsage) {
+    for (const record of cloudFormationUsage.records) {
+      const pid = sdkToProductId.get(record.serviceName.toLowerCase());
+      if (pid) cfProductIds.add(pid);
+
+      const fqn = `${record.serviceName}::${record.resourceTypeName}`;
+      if (!cfUsageByFqn.has(fqn)) {
+        cfUsageByFqn.set(fqn, { stacks: new Set(), properties: {} });
+      }
+      const agg = cfUsageByFqn.get(fqn)!;
+      agg.stacks.add(record.stackName);
+      for (const [key, values] of Object.entries(record.properties ?? {})) {
+        if (!agg.properties[key]) agg.properties[key] = new Map();
+        const valueStacks = agg.properties[key];
+        for (const v of values) {
+          if (!valueStacks.has(v)) valueStacks.set(v, new Set());
+          valueStacks.get(v)!.add(record.stackName);
+        }
+      }
+    }
+  }
+
+  // Select which productIds count as "used" for this mode
+  let usedProductIds: Set<string>;
+  if (mode === UsageFilter.DEPLOYED) {
+    usedProductIds = cfProductIds;
+  } else if (mode === UsageFilter.ACTIVE_USAGE) {
+    usedProductIds = ctProductIds;
+  } else {
+    usedProductIds = new Set([...ctProductIds, ...cfProductIds]);
+  }
+
+  const filteredProducts = filterProducts(products, usedProductIds, includeAllFeaturesPerService);
+
+  const filteredApis = mode === UsageFilter.DEPLOYED ? [] : filterApisScopedToCalled(apis, calledApisBySdkService);
+
+  const filteredCfnResources =
+    mode === UsageFilter.ACTIVE_USAGE ? [] : enrichAndFilterCfnResources(cfnResources, cfUsageByFqn);
+
+  return {
+    products: filteredProducts,
+    apis: filteredApis,
+    cfnResources: filteredCfnResources,
+    lastAnalyzedAt,
+  };
+}
+
+function buildSdkToProductIdMap(apis: ApiService[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const svc of apis) {
+    if (!svc.sdkServiceName || !svc.productID) continue;
+    const lower = svc.sdkServiceName.toLowerCase();
+    map.set(lower, svc.productID);
+    // Collapsed variant (no whitespace/dashes) catches "API Gateway" → "apigateway",
+    // "ACM PCA" → "acmpca", etc.
+    map.set(lower.replace(/[\s-]+/g, ''), svc.productID);
+  }
+  return map;
+}
+
+function filterProducts(
+  products: Product[],
+  usedProductIds: Set<string>,
+  includeAllFeaturesPerService: boolean,
+): Product[] {
+  return products
+    .filter(product => usedProductIds.has(product.productId))
+    .map(product => ({
+      ...product,
+      childProducts: includeAllFeaturesPerService
+        ? (product.childProducts ?? [])
+        : (product.childProducts ?? []).filter(child => usedProductIds.has(child.productId)),
+    }));
+}
+
+/**
+ * Filters apis.json to services whose APIs CloudTrail observed being called,
+ * and further scopes each service's apis[] array to only the called API names.
+ * Services with no called APIs are dropped entirely.
+ */
+function filterApisScopedToCalled(apis: ApiService[], calledApisBySdkService: Map<string, Set<string>>): ApiService[] {
+  const result: ApiService[] = [];
+  for (const svc of apis) {
+    const key = svc.sdkServiceName?.toLowerCase() ?? '';
+    const keyCollapsed = key.replace(/[\s-]+/g, '');
+    const calledApis = calledApisBySdkService.get(key) ?? calledApisBySdkService.get(keyCollapsed);
+    if (!calledApis || calledApis.size === 0) continue;
+
+    const scopedApis = svc.apis.filter(api => calledApis.has(api.apiAction));
+    if (scopedApis.length === 0) continue;
+
+    result.push({ ...svc, apis: scopedApis });
+  }
+  return result;
+}
+
+/**
+ * Filters cfn_resources.json to resource types that CloudFormation observed
+ * in active stacks, enriching each kept resource type with a `usage` subfield
+ * ({ stacks, properties, count }).
+ *
+ * Each kept resource type has its `resourceProperties[]` filtered so that each
+ * property only lists the `resourceConfigurations` the user actually deployed.
+ * For example, if an EC2 Instance has InstanceType `t3.medium`, the output
+ * InstanceType property will contain just the `t3.medium` configuration,
+ * not all 1000+ possible values from the master catalog.
+ */
+function enrichAndFilterCfnResources(
+  cfnResources: CfnResource[],
+  cfUsageByFqn: Map<string, { stacks: Set<string>; properties: Record<string, Map<string, Set<string>>> }>,
+): EnrichedCfnResource[] {
+  const result: EnrichedCfnResource[] = [];
+  for (const entry of cfnResources) {
+    const enrichedTypes: EnrichedCfnResourceType[] = [];
+    for (const rt of entry.resourceTypes) {
+      const fqn = `${entry.serviceName}::${rt.resourceTypeName}`;
+      const usage = cfUsageByFqn.get(fqn);
+      if (!usage) continue;
+
+      // Flat view of observed properties (propName → observed values[]) for
+      // the `usage.properties` summary field. Stacks per value live on each
+      // kept `resourceConfigurations` entry below.
+      const properties: Record<string, string[]> = {};
+      for (const [k, valueStacks] of Object.entries(usage.properties)) {
+        properties[k] = Array.from(valueStacks.keys());
+      }
+
+      // Narrow the master's resourceProperties to just the configurations the
+      // user deployed, and annotate each with the stacks it came from. This
+      // enables per-configuration stack filtering in the UI (e.g., show only
+      // t3.medium configs that came from stack X).
+      const narrowedProperties = (rt.resourceProperties ?? [])
+        .map(prop => {
+          const deployedValues = usage.properties[prop.resourcePropertyName];
+          if (!deployedValues || deployedValues.size === 0) return null;
+          const keptConfigs = prop.resourceConfigurations
+            .filter(cfg => deployedValues.has(cfg.resourceConfigurationName))
+            .map(cfg => ({
+              ...cfg,
+              stacks: Array.from(deployedValues.get(cfg.resourceConfigurationName) ?? []),
+            }));
+          if (keptConfigs.length === 0) return null;
+          return { ...prop, resourceConfigurations: keptConfigs };
+        })
+        .filter((p): p is NonNullable<typeof p> => p !== null);
+
+      enrichedTypes.push({
+        ...rt,
+        resourceProperties: narrowedProperties,
+        usage: {
+          stacks: Array.from(usage.stacks),
+          properties,
+          count: usage.stacks.size,
+        },
+      });
+    }
+    if (enrichedTypes.length === 0) continue;
+    result.push({ serviceName: entry.serviceName, resourceTypes: enrichedTypes });
+  }
+  return result;
+}
+
+// Type guards — Step Functions may pass error objects when a branch fails.
+function isCloudTrailUsage(value: unknown): value is CloudTrailUsage {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return !('status' in value && 'analyzer' in value);
+}
+
+function isCloudFormationUsage(value: unknown): value is CloudFormationUsage {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return 'accountId' in value && 'records' in value;
+}

--- a/source/lambda/usage-route.test.ts
+++ b/source/lambda/usage-route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getUsedCapabilities } from './routes/usage-route';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+const mockGetObject = vi.fn();
+
+vi.mock('./services/s3-client', () => ({
+  S3BucketClient: vi.fn().mockImplementation(() => ({
+    getObject: mockGetObject,
+  })),
+}));
+
+function makeEvent(query: Record<string, string> = {}): APIGatewayProxyEvent {
+  return {
+    httpMethod: 'GET',
+    path: '/capabilities',
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    pathParameters: null,
+    queryStringParameters: Object.keys(query).length > 0 ? query : null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'test',
+      authorizer: null,
+      protocol: 'HTTP/1.1',
+      httpMethod: 'GET',
+      identity: {} as APIGatewayProxyEvent['requestContext']['identity'],
+      path: '/capabilities',
+      stage: 'prod',
+      requestId: 'test-id',
+      requestTimeEpoch: 0,
+      resourceId: '',
+      resourcePath: '',
+    },
+  };
+}
+
+const sampleBody = {
+  products: [{ productId: 'lambda-pid', productName: 'AWS Lambda' }],
+  apis: [{ sdkServiceName: 'Lambda', apis: [{ apiAction: 'Invoke' }] }],
+  cfnResources: [{ serviceName: 'Lambda', resourceTypes: [{ resourceTypeName: 'Function' }] }],
+  lastAnalyzedAt: '2026-05-08T11:37:09.435Z',
+};
+
+describe('usage-route', () => {
+  beforeEach(() => {
+    vi.stubEnv('WEBSITE_BUCKET_NAME', 'test-bucket');
+    mockGetObject.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('validation', () => {
+    it('returns 400 for invalid usageFilter', async () => {
+      const event = makeEvent({ usageFilter: 'invalid' });
+      const result = await getUsedCapabilities(event);
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body).error).toContain('Invalid usageFilter');
+    });
+
+    it('returns 400 for invalid scope', async () => {
+      const event = makeEvent({ scope: 'bogus' });
+      const result = await getUsedCapabilities(event);
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body).error).toContain('Invalid scope');
+    });
+  });
+
+  describe('S3 key construction', () => {
+    it('uses defaults (account + combined) when no params provided', async () => {
+      mockGetObject.mockResolvedValueOnce(JSON.stringify(sampleBody));
+
+      const event = makeEvent();
+      const result = await getUsedCapabilities(event);
+      expect(result.statusCode).toBe(200);
+      expect(mockGetObject).toHaveBeenCalledWith('data/json/used-capabilities-account-combined.json');
+    });
+
+    it('reads the file matching scope=organization + usageFilter=deployed', async () => {
+      mockGetObject.mockResolvedValueOnce(JSON.stringify(sampleBody));
+
+      const event = makeEvent({ scope: 'organization', usageFilter: 'deployed' });
+      await getUsedCapabilities(event);
+      expect(mockGetObject).toHaveBeenCalledWith('data/json/used-capabilities-organization-deployed.json');
+    });
+
+    it('reads the active_usage file for account scope', async () => {
+      mockGetObject.mockResolvedValueOnce(JSON.stringify(sampleBody));
+
+      const event = makeEvent({ usageFilter: 'active_usage' });
+      await getUsedCapabilities(event);
+      expect(mockGetObject).toHaveBeenCalledWith('data/json/used-capabilities-account-active_usage.json');
+    });
+  });
+
+  describe('response', () => {
+    it('returns 200 with the file body verbatim', async () => {
+      mockGetObject.mockResolvedValueOnce(JSON.stringify(sampleBody));
+
+      const event = makeEvent();
+      const result = await getUsedCapabilities(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(JSON.parse(result.body)).toEqual(sampleBody);
+    });
+
+    it('includes CORS headers', async () => {
+      mockGetObject.mockResolvedValueOnce(JSON.stringify(sampleBody));
+
+      const event = makeEvent();
+      const result = await getUsedCapabilities(event);
+
+      expect(result.headers).toMatchObject({
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      });
+    });
+  });
+
+  describe('missing file', () => {
+    it('returns 404 with a helpful message when the file does not exist', async () => {
+      mockGetObject.mockRejectedValueOnce(new Error('NoSuchKey'));
+
+      const event = makeEvent({ scope: 'organization' });
+      const result = await getUsedCapabilities(event);
+
+      expect(result.statusCode).toBe(404);
+      expect(JSON.parse(result.body).error).toContain('scope=organization');
+    });
+  });
+});

--- a/source/lambda/vitest.config.ts
+++ b/source/lambda/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Default config: exclude integration tests so `npm test` stays fast and
+// pure-unit. Integration tests run via `npm run test:it` against a
+// deployed stack.
+export default defineConfig({
+  test: {
+    exclude: ['**/integration-tests/**', 'node_modules/**', 'dist/**'],
+  },
+});

--- a/source/lambda/vitest.it.config.ts
+++ b/source/lambda/vitest.it.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+// Integration-test config. Picks up only `*.it.test.ts` files under
+// integration-tests/. Hits real AWS — slow, requires creds, run on demand.
+export default defineConfig({
+  test: {
+    include: ['integration-tests/**/*.it.test.ts'],
+    // A single end-to-end run can take 60-120s; allow generous per-test
+    // budget. Per-test timeout is also set inline at the test definition.
+    testTimeout: 6 * 60 * 1000,
+    hookTimeout: 60 * 1000,
+    // Don't surface unrelated unit tests if someone runs this by mistake.
+    exclude: ['**/!(*.it).test.ts', 'node_modules/**', 'dist/**'],
+  },
+});

--- a/source/shared/package.json
+++ b/source/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capability-insights/shared",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "build": "echo 'types only, nothing to build'"

--- a/source/shared/types/analysis.ts
+++ b/source/shared/types/analysis.ts
@@ -1,0 +1,21 @@
+/**
+ * Step Functions execution status surfaced in the analyze API response.
+ * Mirrors the subset of AWS Step Functions execution states the API
+ * routes return — RUNNING, SUCCEEDED, FAILED — for clients polling
+ * `GET /analysis?executionArn=...`.
+ */
+export enum ExecutionStatus {
+  RUNNING = 'RUNNING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+}
+
+/**
+ * Analyzers that the usage-analysis state machine can run.
+ * Used in the `analyzers` array of `POST /analysis`.
+ */
+export enum AnalyzerType {
+  CLOUDTRAIL = 'cloudtrail',
+  RESOURCE_EXPLORER = 'resourceExplorer',
+  CLOUDFORMATION = 'cloudformation',
+}

--- a/source/shared/types/availability/regional-availability.ts
+++ b/source/shared/types/availability/regional-availability.ts
@@ -19,6 +19,7 @@ export interface RegionalAvailability {
   homepageUrl?: string;
   regionDates?: Record<RegionCode, string>;
   regionalAvailability?: Record<RegionCode, AvailabilityStatus>;
+  stacks?: string[];
 }
 
 export interface ApiAvailability extends RegionalAvailability {

--- a/source/shared/types/capability/cfn.ts
+++ b/source/shared/types/capability/cfn.ts
@@ -4,6 +4,13 @@ import type { AvailabilityStatus } from '../availability/availability-status';
 export interface CfnResourceConfiguration {
   resourceConfigurationName: string;
   regionalAvailability: Record<RegionCode, AvailabilityStatus>;
+  /**
+   * Stacks that contributed this configuration value. Present only on
+   * personalized ("My stuff") output from the usage decorator; absent on the
+   * master catalog. Lets the UI filter configurations (e.g., `t3.medium`
+   * specifically from `test-assets-*`, not `CapabilityInsightsSampleEnv`).
+   */
+  stacks?: string[];
 }
 
 export interface CfnResourceProperty {
@@ -21,4 +28,26 @@ export interface CfnResourceType {
 export interface CfnResource {
   serviceName: string;
   resourceTypes: CfnResourceType[];
+}
+
+/**
+ * CFN resource type as emitted by the usage decorator's personalized
+ * ("My stuff") output. Adds a `usage` subfield describing which stacks
+ * contributed this resource type and which scalar property values were
+ * observed in those stacks. Absent on the master catalog.
+ */
+export interface EnrichedCfnResourceType extends CfnResourceType {
+  usage?: {
+    stacks: string[];
+    properties: Record<string, string[]>;
+    count: number;
+  };
+}
+
+/**
+ * Decorator-emitted CFN service entry. Same shape as `CfnResource` but
+ * `resourceTypes` are enriched with usage attribution.
+ */
+export interface EnrichedCfnResource extends Omit<CfnResource, 'resourceTypes'> {
+  resourceTypes: EnrichedCfnResourceType[];
 }

--- a/source/shared/types/scope.ts
+++ b/source/shared/types/scope.ts
@@ -1,0 +1,9 @@
+/** Analysis scope — single account or the entire AWS Organization. */
+export const Scope = {
+  ACCOUNT: 'account',
+  ORGANIZATION: 'organization',
+} as const;
+
+export type Scope = (typeof Scope)[keyof typeof Scope];
+
+export const VALID_SCOPES: Scope[] = [Scope.ACCOUNT, Scope.ORGANIZATION];

--- a/source/shared/types/used-capabilities.ts
+++ b/source/shared/types/used-capabilities.ts
@@ -1,0 +1,17 @@
+import type { ApiService } from './capability/api';
+import type { EnrichedCfnResource } from './capability/cfn';
+import type { Product } from './capability/product';
+
+/**
+ * Response shape of the pre-computed `used-capabilities-*.json` files
+ * produced by the usage decorator and served by `GET /capabilities`.
+ *
+ * One file is generated per (scope, usageFilter) pair — six combinations
+ * of {account, organization} × {deployed, active_usage, combined}.
+ */
+export interface UsedCapabilities {
+  products: Product[];
+  apis: ApiService[];
+  cfnResources: EnrichedCfnResource[];
+  lastAnalyzedAt: string;
+}

--- a/source/website/app/clients/capability-insights-client.ts
+++ b/source/website/app/clients/capability-insights-client.ts
@@ -3,6 +3,9 @@ import type { Product } from '@capability-insights/shared/types/capability/produ
 import type { ApiService } from '@capability-insights/shared/types/capability/api';
 import type { CfnResource } from '@capability-insights/shared/types/capability/cfn';
 import type { SyncMetadata } from '@capability-insights/shared/types/sync-metadata';
+import type { UsedCapabilities } from '@capability-insights/shared/types/used-capabilities';
+import { AnalyzerType, ExecutionStatus } from '@capability-insights/shared/types/analysis';
+import { Scope } from '@capability-insights/shared/types/scope';
 import { s3Client } from './s3-client';
 
 export enum DataFormat {
@@ -20,6 +23,13 @@ export enum DataFile {
 export interface ExportUrls {
   json: string;
   csv: string;
+}
+
+export class AnalysisNotEnabledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AnalysisNotEnabledError';
+  }
 }
 
 export class CapabilityInsightsClient {
@@ -49,6 +59,68 @@ export class CapabilityInsightsClient {
     if (!res.ok) throw new Error(`Sync request failed: ${res.status}`);
   }
 
+  /**
+   * Triggers a usage analysis run. Returns the executionArn so callers can
+   * poll status via {@link getAnalysisStatus}. The CloudTrail bucket comes
+   * from the API Lambda's deploy-time configuration; pass `cloudTrailBucket`
+   * to override.
+   */
+  async triggerAnalysis(opts?: { cloudTrailBucket?: string; daysToScan?: number }): Promise<string> {
+    const baseUrl = await this.getApiBaseUrl();
+    const body: Record<string, unknown> = {
+      scope: Scope.ACCOUNT,
+      analyzers: [AnalyzerType.CLOUDTRAIL, AnalyzerType.CLOUDFORMATION],
+    };
+    if (opts?.cloudTrailBucket || opts?.daysToScan) {
+      body.analyzerParams = {
+        cloudtrail: {
+          ...(opts.cloudTrailBucket ? { bucket: opts.cloudTrailBucket } : {}),
+          ...(opts.daysToScan ? { daysToScan: opts.daysToScan } : {}),
+        },
+      };
+    }
+    const res = await fetch(`${baseUrl}/analysis`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      let parsedMessage = '';
+      try {
+        const parsed = JSON.parse(text) as { error?: string; message?: string };
+        parsedMessage = parsed.message || parsed.error || '';
+      } catch {
+        // text wasn't JSON; fall through with empty parsedMessage
+      }
+      if (res.status === 503) {
+        throw new AnalysisNotEnabledError(
+          parsedMessage || 'Usage Analysis is not enabled. Re-run deploy with --enable-usage-analysis.',
+        );
+      }
+      throw new Error(`Analysis request failed: ${res.status}${parsedMessage ? ` ${parsedMessage}` : ''}`);
+    }
+    const data = (await res.json()) as { executionArn: string };
+    return data.executionArn;
+  }
+
+  /**
+   * Polls the status of a previously-triggered analysis. Returns one of:
+   * - `{ status: ExecutionStatus.RUNNING }` while still in progress
+   * - the final result object on success (matches the decorator output shape)
+   * - `{ status: ExecutionStatus.FAILED, error }` on failure.
+   */
+  async getAnalysisStatus(
+    executionArn: string,
+  ): Promise<{ status: ExecutionStatus.RUNNING | ExecutionStatus.FAILED; error?: string } | Record<string, unknown>> {
+    const baseUrl = await this.getApiBaseUrl();
+    const res = await fetch(`${baseUrl}/analysis?executionArn=${encodeURIComponent(executionArn)}`);
+    if (!res.ok) {
+      throw new Error(`Status request failed: ${res.status}`);
+    }
+    return await res.json();
+  }
+
   async listRegions(): Promise<Region[]> {
     return s3Client.fetchJson(this.getDataUrl(DataFile.REGIONS, DataFormat.JSON));
   }
@@ -67,6 +139,20 @@ export class CapabilityInsightsClient {
 
   async getLastSyncTime(): Promise<SyncMetadata | null> {
     return await s3Client.fetchJson<SyncMetadata>('/data/sync-metadata.json');
+  }
+
+  async getUsedCapabilities(
+    scope: 'account' | 'organization' = 'account',
+    usageFilter: 'deployed' | 'active_usage' | 'combined' = 'combined',
+  ): Promise<UsedCapabilities | null> {
+    try {
+      const baseUrl = await this.getApiBaseUrl();
+      const res = await fetch(`${baseUrl}/capabilities?scope=${scope}&usageFilter=${usageFilter}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/source/website/app/components/availability/availability-table-properties.tsx
+++ b/source/website/app/components/availability/availability-table-properties.tsx
@@ -57,7 +57,10 @@ export function createColumns({
   ];
 }
 
-export function createFilteringProperties(regions: Region[]): PropertyFilterProps.FilteringProperty[] {
+export function createFilteringProperties(
+  regions: Region[],
+  extraProperties?: PropertyFilterProps.FilteringProperty[],
+): PropertyFilterProps.FilteringProperty[] {
   return [
     {
       key: 'name',
@@ -73,6 +76,7 @@ export function createFilteringProperties(regions: Region[]): PropertyFilterProp
       operators: enumOperators,
       group: 'properties',
     },
+    ...(extraProperties ?? []),
     ...regions.map(r => ({
       key: `region:${r.Region}`,
       propertyLabel: `${r.RegionLongName} (${r.Region})`,
@@ -95,6 +99,7 @@ export function createFilteringFunction(items: RegionalAvailability[]) {
   const resolveKnownKey = (item: RegionalAvailability, key: string): string | undefined => {
     if (key === 'name') return item.name;
     if (key === 'regionalAvailabilityType') return item.regionalAvailabilityType;
+    if (key === 'stack') return item.stacks?.join(',');
     return undefined;
   };
 
@@ -108,7 +113,24 @@ export function createFilteringFunction(items: RegionalAvailability[]) {
     return undefined;
   };
 
-  const tokenMatches = (value: string | undefined, token: PropertyFilterToken): boolean => {
+  const tokenMatches = (value: string | undefined, token: PropertyFilterToken, key?: string): boolean => {
+    if (key === 'stack' && value) {
+      const stackValues = value.split(',');
+      const tokenValues: string[] = Array.isArray(token.value) ? token.value : [token.value];
+      switch (token.operator) {
+        case '=':
+          return stackValues.some(s => tokenValues.includes(s));
+        case '!=':
+          return !stackValues.some(s => tokenValues.includes(s));
+        case ':':
+          return stackValues.some(s => tokenValues.some(tv => s.toLowerCase().includes(tv.toLowerCase())));
+        case '!:':
+          return !stackValues.some(s => tokenValues.some(tv => s.toLowerCase().includes(tv.toLowerCase())));
+        default:
+          return false;
+      }
+    }
+
     const tokenValues: string[] = Array.isArray(token.value) ? token.value : [token.value];
     const stringValue = value ?? '';
 
@@ -135,7 +157,7 @@ export function createFilteringFunction(items: RegionalAvailability[]) {
         ? item.regionalAvailability?.[token.propertyKey.slice(7)]
         : resolve(item, token.propertyKey);
 
-      if (!tokenMatches(value, token)) return false;
+      if (!tokenMatches(value, token, token.propertyKey)) return false;
     }
     return true;
   };

--- a/source/website/app/components/availability/availability-table.tsx
+++ b/source/website/app/components/availability/availability-table.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import Table from '@cloudscape-design/components/table';
 import PropertyFilter from '@cloudscape-design/components/property-filter';
+import type { PropertyFilterProps } from '@cloudscape-design/components/property-filter';
 import type { CollectionPreferencesProps } from '@cloudscape-design/components/collection-preferences';
 import Pagination from '@cloudscape-design/components/pagination';
 import Header from '@cloudscape-design/components/header';
@@ -27,6 +28,7 @@ interface AvailabilityTableProps<T extends RegionalAvailability> {
   regionalAvailability: T[];
   downloadUrls: ExportUrls;
   loading?: boolean;
+  extraFilteringProperties?: PropertyFilterProps.FilteringProperty[];
 }
 
 export default function AvailabilityTable<T extends RegionalAvailability>({
@@ -37,6 +39,7 @@ export default function AvailabilityTable<T extends RegionalAvailability>({
   regionalAvailability,
   downloadUrls,
   loading = false,
+  extraFilteringProperties,
 }: AvailabilityTableProps<T>) {
   const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>({
     stickyColumns: { first: 1, last: 0 },
@@ -47,7 +50,7 @@ export default function AvailabilityTable<T extends RegionalAvailability>({
     regions,
     nameCell: nameCell as (row: RegionalAvailability) => React.ReactNode,
   });
-  const filteringProperties = createFilteringProperties(regions);
+  const filteringProperties = createFilteringProperties(regions, extraFilteringProperties);
   const filteringFunction = useMemo(() => createFilteringFunction(regionalAvailability), [regionalAvailability]);
 
   const hasNesting = regionalAvailability.some(i => i.parentId !== null);
@@ -85,7 +88,21 @@ export default function AvailabilityTable<T extends RegionalAvailability>({
   const regionFilteringOptions = regions.flatMap(r =>
     regionOptionValues.map(status => ({ propertyKey: `region:${r.Region}`, value: status })),
   );
-  const filteringOptions = [...propertyFilterProps.filteringOptions, ...regionFilteringOptions];
+
+  // Collect unique stack values for the stack filter
+  const stackFilteringOptions = useMemo(() => {
+    const stacks = new Set<string>();
+    for (const item of regionalAvailability) {
+      if (item.stacks) item.stacks.forEach(s => stacks.add(s));
+    }
+    return Array.from(stacks).map(s => ({ propertyKey: 'stack', value: s }));
+  }, [regionalAvailability]);
+
+  const filteringOptions = [
+    ...propertyFilterProps.filteringOptions,
+    ...regionFilteringOptions,
+    ...stackFilteringOptions,
+  ];
 
   return (
     <Table

--- a/source/website/app/mappers/regional-availability.mapper.ts
+++ b/source/website/app/mappers/regional-availability.mapper.ts
@@ -1,6 +1,6 @@
 import { ProductType, type Product } from '@capability-insights/shared/types/capability/product';
 import type { ApiService } from '@capability-insights/shared/types/capability/api';
-import type { CfnResource } from '@capability-insights/shared/types/capability/cfn';
+import type { CfnResource, EnrichedCfnResourceType } from '@capability-insights/shared/types/capability/cfn';
 import type {
   ProductAvailability,
   ApiAvailability,
@@ -99,6 +99,7 @@ export function fromCfnResources(cfnResources: CfnResource[]): CfnAvailability[]
     });
     for (const rt of svc.resourceTypes) {
       const rtId = `${svcId}-${rt.resourceTypeName}`;
+      const rtStacks = (rt as EnrichedCfnResourceType).usage?.stacks;
       rows.push({
         id: rtId,
         parentId: svcId,
@@ -106,6 +107,7 @@ export function fromCfnResources(cfnResources: CfnResource[]): CfnAvailability[]
         regionalAvailabilityType: RegionalAvailabilityType.RESOURCE_TYPE,
         homepageUrl: rt.resourceTypeHomepage,
         regionalAvailability: rt.regionalAvailability,
+        stacks: rtStacks,
       });
       for (const prop of rt.resourceProperties ?? []) {
         const propId = `${rtId}-${prop.resourcePropertyName}`;
@@ -116,12 +118,14 @@ export function fromCfnResources(cfnResources: CfnResource[]): CfnAvailability[]
           regionalAvailabilityType: RegionalAvailabilityType.PROPERTY,
         });
         for (const config of prop.resourceConfigurations) {
+          const configStacks = config.stacks;
           rows.push({
             id: `${propId}-${config.resourceConfigurationName}`,
             parentId: propId,
             name: config.resourceConfigurationName,
             regionalAvailabilityType: RegionalAvailabilityType.CONFIGURATION,
             regionalAvailability: config.regionalAvailability,
+            stacks: configStacks,
           });
         }
       }

--- a/source/website/app/pages/capability-by-region.tsx
+++ b/source/website/app/pages/capability-by-region.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
 import ContentLayout from '@cloudscape-design/components/content-layout';
 import Header from '@cloudscape-design/components/header';
 import SpaceBetween from '@cloudscape-design/components/space-between';
@@ -9,9 +10,11 @@ import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Link from '@cloudscape-design/components/link';
 import Popover from '@cloudscape-design/components/popover';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Toggle from '@cloudscape-design/components/toggle';
 
 import { APP_NAME, PAGE_CAPABILITY_BY_REGION } from '~/constants/app';
 import type { Region } from '@capability-insights/shared/types/capability/region';
+import type { PropertyFilterProps } from '@cloudscape-design/components/property-filter';
 import { capabilityInsightsClient, DataFile } from '~/clients/capability-insights-client';
 import type { SyncMetadata } from '@capability-insights/shared/types/sync-metadata';
 import AvailabilityTable from '~/components/availability/availability-table';
@@ -41,6 +44,18 @@ export default function CapabilityByRegion() {
   const [loading, setLoading] = useState(true);
   const [syncMetadata, setSyncMetadata] = useState<SyncMetadata | null>(null);
 
+  // "My stuff" toggle state — persisted in URL search params
+  const [searchParams, setSearchParams] = useSearchParams();
+  const myStuffEnabled = searchParams.get('myStuff') === 'true';
+  const [myStuffLoading, setMyStuffLoading] = useState(false);
+  const [allProductRows, setAllProductRows] = useState<ProductAvailability[]>([]);
+  const [allApiRows, setAllApiRows] = useState<ApiAvailability[]>([]);
+  const [allCfnRows, setAllCfnRows] = useState<CfnAvailability[]>([]);
+  // Cache for personalized rows — avoids re-fetching on every toggle
+  const [usedProductRows, setUsedProductRows] = useState<ProductAvailability[] | null>(null);
+  const [usedApiRows, setUsedApiRows] = useState<ApiAvailability[] | null>(null);
+  const [usedCfnRows, setUsedCfnRows] = useState<CfnAvailability[] | null>(null);
+
   useEffect(() => {
     async function load() {
       const [r, p, a, c, syncMetadataResult] = await Promise.all([
@@ -51,14 +66,93 @@ export default function CapabilityByRegion() {
         capabilityInsightsClient.getLastSyncTime(),
       ]);
       setRegions(r);
-      setProductRows(fromProducts(p));
-      setApiRows(fromApiServices(a));
-      setCfnRows(fromCfnResources(c));
+      const pRows = fromProducts(p);
+      const aRows = fromApiServices(a);
+      const cRows = fromCfnResources(c);
+      setAllProductRows(pRows);
+      setAllApiRows(aRows);
+      setAllCfnRows(cRows);
       setSyncMetadata(syncMetadataResult);
       setLoading(false);
+
+      if (searchParams.get('myStuff') === 'true') {
+        setMyStuffLoading(true);
+        const usedCapabilities = await capabilityInsightsClient.getUsedCapabilities('account', 'combined');
+        if (usedCapabilities) {
+          const uP = fromProducts(usedCapabilities.products);
+          const uA = fromApiServices(usedCapabilities.apis);
+          const uC = fromCfnResources(usedCapabilities.cfnResources);
+          setUsedProductRows(uP);
+          setUsedApiRows(uA);
+          setUsedCfnRows(uC);
+          setProductRows(uP);
+          setApiRows(uA);
+          setCfnRows(uC);
+        } else {
+          setProductRows(pRows);
+          setApiRows(aRows);
+          setCfnRows(cRows);
+        }
+        setMyStuffLoading(false);
+      } else {
+        setProductRows(pRows);
+        setApiRows(aRows);
+        setCfnRows(cRows);
+      }
     }
     load();
   }, []);
+
+  const handleMyStuffToggle = useCallback(
+    async (checked: boolean) => {
+      setSearchParams(checked ? { myStuff: 'true' } : {}, { replace: true });
+      if (checked) {
+        // Use cached personalized rows if available
+        if (usedProductRows && usedApiRows && usedCfnRows) {
+          setProductRows(usedProductRows);
+          setApiRows(usedApiRows);
+          setCfnRows(usedCfnRows);
+          return;
+        }
+        setMyStuffLoading(true);
+        const usedCapabilities = await capabilityInsightsClient.getUsedCapabilities('account', 'combined');
+        if (usedCapabilities) {
+          const uP = fromProducts(usedCapabilities.products);
+          const uA = fromApiServices(usedCapabilities.apis);
+          const uC = fromCfnResources(usedCapabilities.cfnResources);
+          setUsedProductRows(uP);
+          setUsedApiRows(uA);
+          setUsedCfnRows(uC);
+          setProductRows(uP);
+          setApiRows(uA);
+          setCfnRows(uC);
+        }
+        setMyStuffLoading(false);
+      } else {
+        setProductRows(allProductRows);
+        setApiRows(allApiRows);
+        setCfnRows(allCfnRows);
+      }
+    },
+    [allProductRows, allApiRows, allCfnRows, usedProductRows, usedApiRows, usedCfnRows, setSearchParams],
+  );
+
+  const cfnStackFilterProperty = useMemo((): PropertyFilterProps.FilteringProperty[] => {
+    const allStacks = new Set<string>();
+    for (const row of cfnRows) {
+      if (row.stacks) row.stacks.forEach(s => allStacks.add(s));
+    }
+    if (allStacks.size === 0) return [];
+    return [
+      {
+        key: 'stack',
+        propertyLabel: 'Stack',
+        groupValuesLabel: 'Stack values',
+        operators: [{ operator: '=', tokenType: 'enum' }, { operator: '!=', tokenType: 'enum' }, ':', '!:'],
+        group: 'properties',
+      },
+    ];
+  }, [cfnRows]);
 
   return (
     <ContentLayout
@@ -67,48 +161,53 @@ export default function CapabilityByRegion() {
           variant="h1"
           description="Browse regional availability data for AWS services, API operations, and CloudFormation resource types."
           actions={
-            syncMetadata?.errors?.length ? (
-              <Popover
-                dismissButton={false}
-                position="bottom"
-                size="large"
-                content={
-                  <SpaceBetween size="xs">
-                    {syncMetadata.errors.map((err, i) => (
-                      <StatusIndicator key={i} type="error">
-                        {err}
-                      </StatusIndicator>
-                    ))}
-                    <Link href="/settings" variant="primary" fontSize="body-s">
-                      Go to settings
-                    </Link>
-                  </SpaceBetween>
-                }
-              >
-                <StatusIndicator type="error">
-                  Sync completed with {syncMetadata.errors.length} error(s)
-                </StatusIndicator>
-              </Popover>
-            ) : syncMetadata?.lastSyncTime ? (
-              <Popover
-                dismissButton={false}
-                position="bottom"
-                size="small"
-                content={
-                  <SpaceBetween size="xs">
-                    <StatusIndicator type="success">{formatTimestamp(syncMetadata.lastSyncTime)}</StatusIndicator>
-                    <Box variant="small" color="text-body-secondary">
-                      Data refreshes automatically every 24 hours.
-                    </Box>
-                    <Link href="/settings" variant="primary" fontSize="body-s">
-                      Sync manually
-                    </Link>
-                  </SpaceBetween>
-                }
-              >
-                Last sync: {formatTimestamp(syncMetadata.lastSyncTime)}
-              </Popover>
-            ) : undefined
+            <SpaceBetween direction="horizontal" size="m" alignItems="center">
+              <Toggle onChange={({ detail }) => handleMyStuffToggle(detail.checked)} checked={myStuffEnabled}>
+                My stuff
+              </Toggle>
+              {syncMetadata?.errors?.length ? (
+                <Popover
+                  dismissButton={false}
+                  position="bottom"
+                  size="large"
+                  content={
+                    <SpaceBetween size="xs">
+                      {syncMetadata.errors.map((err, i) => (
+                        <StatusIndicator key={i} type="error">
+                          {err}
+                        </StatusIndicator>
+                      ))}
+                      <Link href="/settings" variant="primary" fontSize="body-s">
+                        Go to settings
+                      </Link>
+                    </SpaceBetween>
+                  }
+                >
+                  <StatusIndicator type="error">
+                    Sync completed with {syncMetadata.errors.length} error(s)
+                  </StatusIndicator>
+                </Popover>
+              ) : syncMetadata?.lastSyncTime ? (
+                <Popover
+                  dismissButton={false}
+                  position="bottom"
+                  size="small"
+                  content={
+                    <SpaceBetween size="xs">
+                      <StatusIndicator type="success">{formatTimestamp(syncMetadata.lastSyncTime)}</StatusIndicator>
+                      <Box variant="small" color="text-body-secondary">
+                        Data refreshes automatically every 24 hours.
+                      </Box>
+                      <Link href="/settings" variant="primary" fontSize="body-s">
+                        Sync manually
+                      </Link>
+                    </SpaceBetween>
+                  }
+                >
+                  Last sync: {formatTimestamp(syncMetadata.lastSyncTime)}
+                </Popover>
+              ) : undefined}
+            </SpaceBetween>
           }
         >
           {PAGE_CAPABILITY_BY_REGION}
@@ -165,7 +264,7 @@ export default function CapabilityByRegion() {
                       <RegionalAvailabilityTypeBadge type={row.regionalAvailabilityType} />
                     </SpaceBetween>
                   )}
-                  loading={loading}
+                  loading={loading || myStuffLoading}
                 />
               ),
             },
@@ -191,7 +290,7 @@ export default function CapabilityByRegion() {
                       <RegionalAvailabilityTypeBadge type={row.regionalAvailabilityType} />
                     </SpaceBetween>
                   )}
-                  loading={loading}
+                  loading={loading || myStuffLoading}
                 />
               ),
             },
@@ -205,6 +304,7 @@ export default function CapabilityByRegion() {
                   regions={regions}
                   regionalAvailability={cfnRows}
                   downloadUrls={capabilityInsightsClient.exportUrls(DataFile.CFN_RESOURCES)}
+                  extraFilteringProperties={cfnStackFilterProperty}
                   nameCell={row => (
                     <SpaceBetween direction="horizontal" size="xs">
                       {row.homepageUrl ? (
@@ -217,7 +317,7 @@ export default function CapabilityByRegion() {
                       <RegionalAvailabilityTypeBadge type={row.regionalAvailabilityType} />
                     </SpaceBetween>
                   )}
-                  loading={loading}
+                  loading={loading || myStuffLoading}
                 />
               ),
             },

--- a/source/website/app/pages/settings.tsx
+++ b/source/website/app/pages/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ContentLayout from '@cloudscape-design/components/content-layout';
 import Header from '@cloudscape-design/components/header';
 import Container from '@cloudscape-design/components/container';
@@ -9,9 +9,10 @@ import Box from '@cloudscape-design/components/box';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import Popover from '@cloudscape-design/components/popover';
 import { PAGE_SETTINGS } from '~/constants/app';
-import { capabilityInsightsClient } from '~/clients/capability-insights-client';
+import { AnalysisNotEnabledError, capabilityInsightsClient } from '~/clients/capability-insights-client';
 import { formatTimestamp } from '~/utils/time-utils';
 import type { SyncMetadata } from '@capability-insights/shared/types/sync-metadata';
+import { ExecutionStatus } from '@capability-insights/shared/types/analysis';
 
 import type { RouteHandle } from '~/types/route';
 
@@ -21,14 +22,34 @@ export function meta() {
   return [{ title: PAGE_SETTINGS }];
 }
 
+/**
+ * How often the Settings page polls `GET /analysis` while an analysis run
+ * is in progress.
+ */
+const POLL_INTERVAL_MS = 5000;
+
+type AnalysisStatus = 'idle' | 'running' | 'success' | 'error' | 'not-enabled';
+
 export default function Settings() {
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [syncMetadata, setSyncMetadata] = useState<SyncMetadata | null>(null);
 
+  // Usage analysis state
+  const [analysisStatus, setAnalysisStatus] = useState<AnalysisStatus>('idle');
+  const [analysisError, setAnalysisError] = useState<string>('');
+  const [analysisResult, setAnalysisResult] = useState<Record<string, unknown> | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     capabilityInsightsClient.getLastSyncTime().then(setSyncMetadata);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (pollTimer.current) clearTimeout(pollTimer.current);
+    };
   }, []);
 
   const handleSync = async () => {
@@ -45,57 +66,167 @@ export default function Settings() {
     }
   };
 
+  const pollAnalysis = (executionArn: string) => {
+    const tick = async () => {
+      try {
+        const result = await capabilityInsightsClient.getAnalysisStatus(executionArn);
+        if ('status' in result && result.status === ExecutionStatus.RUNNING) {
+          pollTimer.current = setTimeout(tick, POLL_INTERVAL_MS);
+          return;
+        }
+        if ('status' in result && result.status === ExecutionStatus.FAILED) {
+          setAnalysisStatus('error');
+          setAnalysisError(typeof result.error === 'string' ? result.error : 'Analysis failed');
+          return;
+        }
+        setAnalysisResult(result as Record<string, unknown>);
+        setAnalysisStatus('success');
+      } catch (e) {
+        setAnalysisStatus('error');
+        setAnalysisError(e instanceof Error ? e.message : String(e));
+      }
+    };
+    void tick();
+  };
+
+  const handleAnalyze = async () => {
+    setAnalysisStatus('running');
+    setAnalysisError('');
+    setAnalysisResult(null);
+    try {
+      const executionArn = await capabilityInsightsClient.triggerAnalysis();
+      pollAnalysis(executionArn);
+    } catch (e) {
+      if (e instanceof AnalysisNotEnabledError) {
+        setAnalysisStatus('not-enabled');
+        setAnalysisError(e.message);
+        return;
+      }
+      setAnalysisStatus('error');
+      setAnalysisError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
   return (
     <ContentLayout header={<Header variant="h1">{PAGE_SETTINGS}</Header>}>
-      <Container header={<Header variant="h2">Data synchronization</Header>}>
-        <SpaceBetween size="m">
-          <Alert type="info">Data is automatically refreshed every 24 hours.</Alert>
-          {syncMetadata?.errors?.length ? (
-            <Popover
-              dismissButton={false}
-              position="bottom"
-              size="large"
-              content={
+      <SpaceBetween size="l">
+        <Container header={<Header variant="h2">Data synchronization</Header>}>
+          <SpaceBetween size="m">
+            <Alert type="info">Data is automatically refreshed every 24 hours.</Alert>
+            {syncMetadata?.errors?.length ? (
+              <Popover
+                dismissButton={false}
+                position="bottom"
+                size="large"
+                content={
+                  <SpaceBetween size="xs">
+                    {syncMetadata.errors.map((err, i) => (
+                      <StatusIndicator key={i} type="error">
+                        {err}
+                      </StatusIndicator>
+                    ))}
+                  </SpaceBetween>
+                }
+              >
+                <StatusIndicator type="error">
+                  Sync completed with {syncMetadata.errors.length} error(s)
+                </StatusIndicator>
+              </Popover>
+            ) : syncMetadata?.lastSyncTime ? (
+              <StatusIndicator type="success">
+                Last synced: {formatTimestamp(syncMetadata.lastSyncTime)}
+              </StatusIndicator>
+            ) : (
+              <StatusIndicator type="pending">No sync has completed yet</StatusIndicator>
+            )}
+            <Box variant="small" color="text-body-secondary">
+              If data appears outdated, use the button below to sync manually. This runs in the background and may take
+              a few minutes. Refresh the page to see the update.
+            </Box>
+            <Button onClick={handleSync} loading={loading}>
+              Sync capability data
+            </Button>
+            {status === 'success' && (
+              <Alert type="success">
+                Data sync has been triggered. It may take a few minutes for updated data to appear.
+              </Alert>
+            )}
+            {status === 'error' && (
+              <Alert type="error">
                 <SpaceBetween size="xs">
-                  {syncMetadata.errors.map((err, i) => (
-                    <StatusIndicator key={i} type="error">
-                      {err}
-                    </StatusIndicator>
-                  ))}
+                  <Box>Failed to trigger data sync.</Box>
+                  <Box variant="small" color="text-body-secondary">
+                    {errorMessage}
+                  </Box>
                 </SpaceBetween>
-              }
+              </Alert>
+            )}
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Usage analysis</Header>}>
+          <SpaceBetween size="m">
+            <Alert type="info">
+              Analyzes CloudTrail and CloudFormation in this account to personalize the dashboard with what you actually
+              use.
+            </Alert>
+            <Box variant="small" color="text-body-secondary">
+              Triggers a new analysis run. Takes a few minutes. The CloudTrail bucket configured at deploy time is used.
+              Refresh the page to see updated personalization.
+            </Box>
+            <Button
+              onClick={handleAnalyze}
+              loading={analysisStatus === 'running'}
+              disabled={analysisStatus === 'running'}
             >
-              <StatusIndicator type="error">Sync completed with {syncMetadata.errors.length} error(s)</StatusIndicator>
-            </Popover>
-          ) : syncMetadata?.lastSyncTime ? (
-            <StatusIndicator type="success">Last synced: {formatTimestamp(syncMetadata.lastSyncTime)}</StatusIndicator>
-          ) : (
-            <StatusIndicator type="pending">No sync has completed yet</StatusIndicator>
-          )}
-          <Box variant="small" color="text-body-secondary">
-            If data appears outdated, use the button below to sync manually. This runs in the background and may take a
-            few minutes. Refresh the page to see the update.
-          </Box>
-          <Button onClick={handleSync} loading={loading}>
-            Sync capability data
-          </Button>
-          {status === 'success' && (
-            <Alert type="success">
-              Data sync has been triggered. It may take a few minutes for updated data to appear.
-            </Alert>
-          )}
-          {status === 'error' && (
-            <Alert type="error">
-              <SpaceBetween size="xs">
-                <Box>Failed to trigger data sync.</Box>
-                <Box variant="small" color="text-body-secondary">
-                  {errorMessage}
-                </Box>
-              </SpaceBetween>
-            </Alert>
-          )}
-        </SpaceBetween>
-      </Container>
+              Run usage analysis
+            </Button>
+            {analysisStatus === 'running' && (
+              <StatusIndicator type="loading">
+                Analysis in progress — this can take 1-5 minutes for the first run
+              </StatusIndicator>
+            )}
+            {analysisStatus === 'success' && analysisResult && (
+              <Alert type="success">
+                <SpaceBetween size="xs">
+                  <Box>Analysis complete.</Box>
+                  {typeof analysisResult.deployed === 'number' && (
+                    <Box variant="small" color="text-body-secondary">
+                      deployed: {String(analysisResult.deployed)} · active_usage: {String(analysisResult.active_usage)}{' '}
+                      · combined: {String(analysisResult.combined)}
+                    </Box>
+                  )}
+                </SpaceBetween>
+              </Alert>
+            )}
+            {analysisStatus === 'not-enabled' && (
+              <Alert type="info" header="Usage Analysis is not enabled">
+                <SpaceBetween size="xs">
+                  <Box>
+                    The optional Usage Analysis stack is not deployed. To enable personalization, re-run deploy with{' '}
+                    <code>--enable-usage-analysis</code>.
+                  </Box>
+                  {analysisError && (
+                    <Box variant="small" color="text-body-secondary">
+                      {analysisError}
+                    </Box>
+                  )}
+                </SpaceBetween>
+              </Alert>
+            )}
+            {analysisStatus === 'error' && (
+              <Alert type="error">
+                <SpaceBetween size="xs">
+                  <Box>Failed to run usage analysis.</Box>
+                  <Box variant="small" color="text-body-secondary">
+                    {analysisError}
+                  </Box>
+                </SpaceBetween>
+              </Alert>
+            )}
+          </SpaceBetween>
+        </Container>
+      </SpaceBetween>
     </ContentLayout>
   );
 }


### PR DESCRIPTION
## v1.1.0 — Personalization layer

Adds an opt-in personalization layer on top of the base dashboard. When enabled, the dashboard offers a **My stuff** toggle that filters services, APIs, and CloudFormation resources to only what's actually used in your account.

### What's new

- **Usage Analysis stack** (`--enable-usage-analysis`): a new opt-in CloudFormation stack with a Step Functions state machine that orchestrates two analyzers (CloudTrail + CloudFormation) and a decorator. Output is written back to the website bucket as personalized data files.
- **Settings page**: new "Run usage analysis" button that triggers analysis on demand and polls for completion.
- **Capability by Region page**: new "My stuff" toggle in the page header. Active CloudFormation tab gains a Stack filter for resource types in use.
- **Auto-discovery**: deploy script auto-discovers the CloudTrail bucket from `describe-trails` if `--cloudtrail-bucket` is omitted.
- **Lake Formation bootstrap**: stack provisions cleanly on a fresh account by adding the analyzer role and the deployer role as Data Lake Admins (preserves any pre-existing admins).

### Architecture

| Component | Purpose |
|---|---|
| Step Functions State Machine | Runs two analyzers in parallel, then the decorator |
| CloudTrail Analyzer Lambda | Athena queries over CloudTrail logs |
| CloudFormation Analyzer Lambda | Inspects active CloudFormation stacks |
| Usage Decorator Lambda | Joins analyzer output with the master catalog |
| Glue Database / Table + LF Permissions | Schema over the CloudTrail bucket for Athena |
| EventBridge Rule | Daily scheduled runs (configurable) |

### Versions

- `package.json` (root + `source/constructs`, `source/lambda`, `source/shared`) bumped to `1.1.0`.

### Testing

- 83/83 lambda unit tests + 11/11 constructs unit tests passing.
- End-to-end verified on two fresh accounts: bootstrap CR ran, auto-discovery picked the right CloudTrail bucket, full analysis run produced personalized data, and the My stuff toggle / Stack filter rendered with non-zero counts.
