### PR TITLE
docs: Restore Architecture heading and fix stack count

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,9 @@ The personalized data is produced by analyzers that read your CloudTrail logs an
 
 ![Run usage analysis](docs/images/user-guide-run-analysis.png)
 
-This repository provides two CloudFormation stacks:
+## Architecture
+
+This repository provides three CloudFormation stacks:
 
 ### Capability Insights Stack
 


### PR DESCRIPTION
## Summary

Restores the `## Architecture` top-level heading that was inadvertently dropped during the PR #27 User Guide refresh. Without it, two anchor links currently 404:

- TOC: `- [Architecture](#architecture)`
- Overview prose: "For a detailed breakdown of all resources, see [Architecture](#architecture)."

The body content (Capability Insights Stack / Sample Environment Stack / Usage Analysis Stack subsections with their resource tables) is still present — it was just orphaned without a parent heading.

Also fixes a stale stack count: the Architecture section's intro paragraph said "two CloudFormation stacks" but the section actually documents three.

## Changes

```
@@ -260,7 +260,9 @@
 ![Run usage analysis](docs/images/user-guide-run-analysis.png)
 
-This repository provides two CloudFormation stacks:
+## Architecture
+
+This repository provides three CloudFormation stacks:
 
 ### Capability Insights Stack
```

## Tested

- `## Architecture` heading restored at line 263
- TOC link `#architecture` now resolves
- Overview prose link `#architecture` now resolves
- Three subsections (Capability Insights / Sample Environment / Usage Analysis) read consistently as children of the restored heading
