### PR TITLE
chore(release): bump to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capability-insights-for-aws",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "workspaces": [
         "source/shared",
@@ -8579,7 +8579,7 @@
     },
     "source/constructs": {
       "name": "@capability-insights/constructs",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@tsconfig/node-lts": "^20.1.3",
@@ -8614,7 +8614,7 @@
     },
     "source/shared": {
       "name": "@capability-insights/shared",
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     "source/website": {
       "name": "@capability-insights/website",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capability-insights/constructs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "private": true,
   "main": "dist/lib/index.js",

--- a/source/shared/package.json
+++ b/source/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capability-insights/shared",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary (required)

Release commit: bumps the package version from `1.1.0` to `1.2.0`. Merging this PR triggers the v1.2.0 GitHub Release with deployment artifacts (`build-assets.zip`).

## Details (required)

The Policy Enforcer feature shipped in **#31** and its user-facing documentation in **#32**. Both should land before this PR. This PR is intentionally tiny and isolated so the release timing is decoupled from any code or doc iteration.

Bumps `1.1.0` → `1.2.0` in:
- `package.json` (root)
- `source/constructs/package.json`
- `source/shared/package.json`

The lambda workspace version is left at `1.0.0` to preserve the existing inconsistency carried over from v1.1.0; not in scope for this PR.

`package-lock.json` is regenerated against the new versions.

## Testing (required)

- [x] Unit tests
- [x] Local development server
- [x] Full deployment

**How did you test this?**

- 226 unit tests pass on the merged tree (204 Lambda, 22 Constructs).
- `npm run lint` clean (eslint + prettier, 0 warnings).
- `npm run build` succeeds end-to-end including CDK synth of all three stacks.
- A version bump only affects the release artifact name; no behavioural change to deployed resources, so a fresh full deploy from this branch isn't needed.
