### PR TITLE
fix(website): show sub-service features as root rows and fix OR filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ Thumbs.db
 
 # Logs
 *.log
+# npm
+.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,64 @@
         "typescript-eslint": "^8.44.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.263",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
@@ -2077,6 +2135,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@capability-insights/constructs": {
       "resolved": "source/constructs",
       "link": true
@@ -2176,6 +2247,146 @@
       "dependencies": {
         "@material/material-color-utilities": "^0.3.0",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -2815,6 +3026,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -4252,10 +4481,106 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tsconfig/node-lts": {
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-20.1.3.tgz",
       "integrity": "sha512-m3b7EP2U+h5tNSpaBMfcTuHmHn04wrgRPQQrfKt75YIPq6kPs2153/KfPHdqkEWGx5pEBvS6rnvToT+yTtC1iw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4831,6 +5156,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4872,6 +5207,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -5395,6 +5740,16 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -5794,6 +6149,20 @@
         "fastparse": "^1.1.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -5831,6 +6200,20 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "1"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/date-fns": {
@@ -5914,6 +6297,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -5933,6 +6326,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5978,6 +6378,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -6716,6 +7129,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -6785,6 +7211,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6835,6 +7271,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbot": {
       "version": "5.1.36",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.36.tgz",
@@ -6867,6 +7310,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7006,6 +7500,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7024,6 +7528,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7092,6 +7603,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7379,6 +7900,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7540,6 +8074,41 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7722,6 +8291,30 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7802,6 +8395,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -8061,6 +8667,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8123,6 +8742,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8184,6 +8810,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+      "integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.7"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+      "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -8191,6 +8837,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8305,6 +8977,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8602,11 +9284,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/weekstart": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/weekstart/-/weekstart-2.0.0.tgz",
       "integrity": "sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -8651,6 +9381,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -8666,6 +9406,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -8742,8 +9489,13 @@
       },
       "devDependencies": {
         "@react-router/dev": "7.13.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "jsdom": "^29.1.1",
         "vite": "^7.1.7",
         "vite-tsconfig-paths": "^5.1.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/source/website/app/components/availability/availability-table-properties.test.ts
+++ b/source/website/app/components/availability/availability-table-properties.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import type { PropertyFilterQuery } from '@cloudscape-design/collection-hooks';
+import { ProductType, type Product } from '@capability-insights/shared/types/capability/product';
+import { AvailabilityStatus } from '@capability-insights/shared/types/availability/availability-status';
+import {
+  RegionalAvailabilityType,
+  type RegionalAvailability,
+} from '@capability-insights/shared/types/availability/regional-availability';
+import { createFilteringFunction } from './availability-table-properties';
+import { fromProducts } from '~/mappers/regional-availability.mapper';
+
+const AVAILABLE = { 'us-east-1': AvailabilityStatus.AVAILABLE };
+const NOT_AVAILABLE = { 'us-east-1': AvailabilityStatus.NOT_AVAILABLE };
+
+function productsFixture(): Product[] {
+  return [
+    {
+      productId: 'route-53',
+      productName: 'Amazon Route 53',
+      productType: ProductType.SERVICE,
+      regionalAvailability: AVAILABLE,
+      childProducts: [
+        {
+          productId: 'route-53-domains',
+          productName: 'Route 53 Domains',
+          productType: ProductType.FEATURE,
+          regionalAvailability: AVAILABLE,
+        },
+        {
+          productId: 'private-dns',
+          productName: 'Amazon Route 53 Private DNS',
+          productType: ProductType.SERVICE,
+          regionalAvailability: AVAILABLE,
+          childProducts: [
+            {
+              productId: 'geolocation-routing',
+              productName: 'Geolocation Routing',
+              productType: ProductType.FEATURE,
+              regionalAvailability: NOT_AVAILABLE,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      productId: 's3',
+      productName: 'Amazon S3',
+      productType: ProductType.SERVICE,
+      regionalAvailability: AVAILABLE,
+    },
+  ];
+}
+
+/**
+ * Applies the filtering function the same way useCollection does: item by
+ * item, in array order (parents are emitted before children by the mappers).
+ */
+function applyFilter(items: RegionalAvailability[], query: PropertyFilterQuery): RegionalAvailability[] {
+  const filteringFunction = createFilteringFunction(items);
+  return items.filter(item => filteringFunction(item, query));
+}
+
+function nameContains(value: string): PropertyFilterQuery {
+  return { operation: 'and', tokens: [{ propertyKey: 'name', operator: ':', value }] };
+}
+
+describe('createFilteringFunction with product rows (including duplicated child services)', () => {
+  const rows = fromProducts(productsFixture());
+
+  it('matching a parent service includes all of its children, including the duplicated leaf', () => {
+    const result = applyFilter(rows, nameContains('Amazon Route 53'));
+    const names = result.map(r => `${r.name}${r.parentId === null ? ' (root)' : ''}`);
+    expect(names).toContain('Amazon Route 53 (root)');
+    expect(names).toContain('Route 53 Domains');
+    // The duplicated sub-service leaf under the parent is included via ancestor match...
+    expect(result.some(r => r.id === 'route-53:private-dns')).toBe(true);
+    // ...and its promoted root row matches on its own name, bringing its features along.
+    expect(result.some(r => r.id === 'private-dns' && r.parentId === null)).toBe(true);
+    expect(result.some(r => r.id === 'geolocation-routing')).toBe(true);
+  });
+
+  it('matching a sub-service by name includes both instances and its features', () => {
+    const result = applyFilter(rows, nameContains('Private DNS'));
+    expect(result.map(r => r.id).sort()).toEqual(['geolocation-routing', 'private-dns', 'route-53:private-dns'].sort());
+  });
+
+  it('matching a grandchild feature returns only that row (no unrelated rows)', () => {
+    const result = applyFilter(rows, nameContains('Geolocation'));
+    expect(result.map(r => r.id)).toEqual(['geolocation-routing']);
+  });
+
+  it('does not leak unrelated services into filtered results', () => {
+    const result = applyFilter(rows, nameContains('Route 53'));
+    expect(result.some(r => r.id === 's3')).toBe(false);
+  });
+
+  it('filters by type = Service, matching duplicated leaves, promoted roots, and their descendants', () => {
+    const result = applyFilter(rows, {
+      operation: 'and',
+      tokens: [{ propertyKey: 'regionalAvailabilityType', operator: '=', value: [RegionalAvailabilityType.SERVICE] }],
+    });
+    const ids = result.map(r => r.id);
+    expect(ids).toContain('route-53');
+    expect(ids).toContain('route-53:private-dns');
+    expect(ids).toContain('private-dns');
+    expect(ids).toContain('s3');
+    // Children of matched services are included by ancestor cascade (existing behavior).
+    expect(ids).toContain('route-53-domains');
+    expect(ids).toContain('geolocation-routing');
+  });
+
+  it('filters by region availability without cascading to non-matching children', () => {
+    const result = applyFilter(rows, {
+      operation: 'and',
+      tokens: [{ propertyKey: 'region:us-east-1', operator: '=', value: [AvailabilityStatus.NOT_AVAILABLE] }],
+    });
+    expect(result.map(r => r.id)).toEqual(['geolocation-routing']);
+  });
+
+  it('supports negation on names', () => {
+    const result = applyFilter(rows, {
+      operation: 'and',
+      tokens: [{ propertyKey: 'name', operator: '!:', value: 'Route 53' }],
+    });
+    expect(result.map(r => r.id)).toEqual(['geolocation-routing', 's3']);
+  });
+
+  it('resets matched-ancestor state between different queries', () => {
+    const filteringFunction = createFilteringFunction(rows);
+    const first = nameContains('Amazon Route 53');
+    const second = nameContains('Amazon S3');
+    rows.forEach(item => filteringFunction(item, first));
+    const result = rows.filter(item => filteringFunction(item, second));
+    expect(result.map(r => r.id)).toEqual(['s3']);
+  });
+
+  it('returns every row for an empty query', () => {
+    const result = applyFilter(rows, { operation: 'and', tokens: [] });
+    expect(result).toHaveLength(rows.length);
+  });
+});
+
+describe('createFilteringFunction OR operation', () => {
+  const rows = fromProducts(productsFixture());
+
+  it('matches rows satisfying any token, not all tokens', () => {
+    const result = applyFilter(rows, {
+      operation: 'or',
+      tokens: [
+        { propertyKey: 'name', operator: ':', value: 'Route 53 Domains' },
+        { propertyKey: 'name', operator: ':', value: 'Amazon S3' },
+      ],
+    });
+    // Under the old AND-only behavior this returned nothing: no row contains both strings.
+    expect(result.map(r => r.id).sort()).toEqual(['route-53-domains', 's3'].sort());
+  });
+
+  it('OR-matched parents still cascade to their children, including duplicated sub-services', () => {
+    const result = applyFilter(rows, {
+      operation: 'or',
+      tokens: [
+        { propertyKey: 'name', operator: '=', value: 'Amazon Route 53' },
+        { propertyKey: 'name', operator: '=', value: 'Amazon S3' },
+      ],
+    });
+    const ids = result.map(r => r.id);
+    // Both exact-name matches...
+    expect(ids).toContain('route-53');
+    expect(ids).toContain('s3');
+    // ...and all of Route 53's children via ancestor cascade.
+    expect(ids).toContain('route-53-domains');
+    expect(ids).toContain('route-53:private-dns');
+    // The promoted root's own name did not match, and its parent (none) did not match.
+    expect(ids).not.toContain('private-dns');
+  });
+
+  it('supports OR across different property types (name and region availability)', () => {
+    const result = applyFilter(rows, {
+      operation: 'or',
+      tokens: [
+        { propertyKey: 'name', operator: '=', value: 'Amazon S3' },
+        { propertyKey: 'region:us-east-1', operator: '=', value: [AvailabilityStatus.NOT_AVAILABLE] },
+      ],
+    });
+    expect(result.map(r => r.id).sort()).toEqual(['geolocation-routing', 's3'].sort());
+  });
+
+  it('behaves identically to AND for a single token', () => {
+    const orResult = applyFilter(rows, {
+      operation: 'or',
+      tokens: [{ propertyKey: 'name', operator: ':', value: 'Private DNS' }],
+    });
+    const andResult = applyFilter(rows, nameContains('Private DNS'));
+    expect(orResult).toEqual(andResult);
+  });
+
+  it('returns every row when no token is evaluable (free-text-only query)', () => {
+    const result = applyFilter(rows, {
+      operation: 'or',
+      tokens: [{ operator: ':', value: 'Route 53' }],
+    });
+    expect(result).toHaveLength(rows.length);
+  });
+
+  it('does not change AND semantics: all tokens must still match', () => {
+    const result = applyFilter(rows, {
+      operation: 'and',
+      tokens: [
+        { propertyKey: 'name', operator: ':', value: 'Route 53' },
+        { propertyKey: 'name', operator: ':', value: 'Domains' },
+      ],
+    });
+    expect(result.map(r => r.id)).toEqual(['route-53-domains']);
+  });
+});
+
+describe('createFilteringFunction value inheritance', () => {
+  it('children inherit stack values from their parent chain', () => {
+    const items: RegionalAvailability[] = [
+      {
+        id: 'parent',
+        parentId: null,
+        name: 'Parent',
+        regionalAvailabilityType: RegionalAvailabilityType.RESOURCE_TYPE,
+        stacks: ['stack-a'],
+      },
+      {
+        id: 'child',
+        parentId: 'parent',
+        name: 'Child',
+        regionalAvailabilityType: RegionalAvailabilityType.PROPERTY,
+      },
+    ];
+    const result = applyFilter(items, {
+      operation: 'and',
+      tokens: [{ propertyKey: 'stack', operator: '=', value: ['stack-a'] }],
+    });
+    expect(result.map(r => r.id)).toEqual(['parent', 'child']);
+  });
+
+  it('tolerates rows whose parentId is missing from the row set', () => {
+    const items: RegionalAvailability[] = [
+      {
+        id: 'orphan',
+        parentId: 'missing-parent',
+        name: 'Orphan',
+        regionalAvailabilityType: RegionalAvailabilityType.FEATURE,
+      },
+    ];
+    expect(() => applyFilter(items, nameContains('Orphan'))).not.toThrow();
+    expect(applyFilter(items, nameContains('Orphan')).map(r => r.id)).toEqual(['orphan']);
+  });
+});

--- a/source/website/app/components/availability/availability-table-properties.tsx
+++ b/source/website/app/components/availability/availability-table-properties.tsx
@@ -148,18 +148,25 @@ export function createFilteringFunction(items: RegionalAvailability[]) {
     }
   };
 
-  const matchesTokens = (item: RegionalAvailability, tokens: readonly PropertyFilterToken[]): boolean => {
-    for (const token of tokens) {
-      if (!token.propertyKey) continue;
+  const matchesTokens = (
+    item: RegionalAvailability,
+    tokens: readonly PropertyFilterToken[],
+    operation: PropertyFilterQuery['operation'],
+  ): boolean => {
+    // Tokens without a propertyKey (free text, token groups) are not evaluated
+    // and act as "no constraint", preserving longstanding behavior.
+    const evaluableTokens = tokens.filter(token => token.propertyKey);
+    if (evaluableTokens.length === 0) return true;
 
-      const isRegion = token.propertyKey.startsWith('region:');
+    const matchesToken = (token: PropertyFilterToken): boolean => {
+      const isRegion = token.propertyKey!.startsWith('region:');
       const value = isRegion
-        ? item.regionalAvailability?.[token.propertyKey.slice(7)]
-        : resolve(item, token.propertyKey);
+        ? item.regionalAvailability?.[token.propertyKey!.slice(7)]
+        : resolve(item, token.propertyKey!);
+      return tokenMatches(value, token, token.propertyKey);
+    };
 
-      if (!tokenMatches(value, token, token.propertyKey)) return false;
-    }
-    return true;
+    return operation === 'or' ? evaluableTokens.some(matchesToken) : evaluableTokens.every(matchesToken);
   };
 
   const hasMatchedAncestor = (item: RegionalAvailability): boolean => {
@@ -181,7 +188,7 @@ export function createFilteringFunction(items: RegionalAvailability[]) {
 
     const tokens = query.tokenGroups ?? query.tokens;
 
-    if (matchesTokens(item, tokens as readonly PropertyFilterToken[])) {
+    if (matchesTokens(item, tokens as readonly PropertyFilterToken[], query.operation)) {
       matchedIds.add(item.id);
       return true;
     }

--- a/source/website/app/components/availability/availability-table.test.tsx
+++ b/source/website/app/components/availability/availability-table.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import { act, render } from '@testing-library/react';
+import createWrapper from '@cloudscape-design/components/test-utils/dom';
+import type { TableWrapper } from '@cloudscape-design/components/test-utils/dom';
+import { ProductType, type Product } from '@capability-insights/shared/types/capability/product';
+import type { ApiService } from '@capability-insights/shared/types/capability/api';
+import type { CfnResource } from '@capability-insights/shared/types/capability/cfn';
+import type { Region } from '@capability-insights/shared/types/capability/region';
+import type { RegionalAvailability } from '@capability-insights/shared/types/availability/regional-availability';
+import { AvailabilityStatus } from '@capability-insights/shared/types/availability/availability-status';
+import { fromProducts, fromApiServices, fromCfnResources } from '~/mappers/regional-availability.mapper';
+import AvailabilityTable from './availability-table';
+
+const REGIONS: Region[] = [
+  {
+    Region: 'us-east-1',
+    RegionLongName: 'US East (N. Virginia)',
+    Partition: 'aws',
+    RegionStatus: 'AVAILABLE',
+    RequireRegionOptIn: false,
+  },
+];
+
+const AVAILABLE = { 'us-east-1': AvailabilityStatus.AVAILABLE };
+
+const DOWNLOAD_URLS = { json: '/data/json/test.json', csv: '/data/csv/test.csv' };
+
+function productsFixture(): Product[] {
+  return [
+    {
+      productId: 'route-53',
+      productName: 'Amazon Route 53',
+      productType: ProductType.SERVICE,
+      regionalAvailability: AVAILABLE,
+      childProducts: [
+        {
+          productId: 'route-53-domains',
+          productName: 'Route 53 Domains',
+          productType: ProductType.FEATURE,
+          regionalAvailability: AVAILABLE,
+        },
+        {
+          productId: 'private-dns',
+          productName: 'Amazon Route 53 Private DNS',
+          productType: ProductType.SERVICE,
+          regionalAvailability: AVAILABLE,
+          childProducts: [
+            {
+              productId: 'geolocation-routing',
+              productName: 'Geolocation Routing',
+              productType: ProductType.FEATURE,
+              regionalAvailability: AVAILABLE,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      productId: 's3',
+      productName: 'Amazon S3',
+      productType: ProductType.SERVICE,
+      regionalAvailability: AVAILABLE,
+    },
+  ];
+}
+
+function renderTable(rows: RegionalAvailability[], title = 'Services'): TableWrapper {
+  const { container } = render(
+    <AvailabilityTable
+      title={title}
+      nameHeader="Name"
+      nameCell={row => row.name}
+      regions={REGIONS}
+      regionalAvailability={rows}
+      downloadUrls={DOWNLOAD_URLS}
+    />,
+  );
+  const table = createWrapper(container).findTable();
+  expect(table).not.toBeNull();
+  return table!;
+}
+
+function rowNames(table: TableWrapper): string[] {
+  return table.findRows().map((_row, i) => table.findBodyCell(i + 1, 1)!.getElement().textContent ?? '');
+}
+
+function expandRow(table: TableWrapper, rowIndex: number): void {
+  act(() => {
+    table.findExpandToggle(rowIndex)!.click();
+  });
+}
+
+describe('AvailabilityTable with product rows', () => {
+  it('initially shows only root rows, including promoted child services', () => {
+    const table = renderTable(fromProducts(productsFixture()));
+    expect(rowNames(table)).toEqual(['Amazon Route 53', 'Amazon Route 53 Private DNS', 'Amazon S3']);
+  });
+
+  it('expanding a parent reveals features and the duplicated sub-service leaf', () => {
+    const table = renderTable(fromProducts(productsFixture()));
+    expandRow(table, 1);
+    expect(rowNames(table)).toEqual([
+      'Amazon Route 53',
+      'Route 53 Domains',
+      'Amazon Route 53 Private DNS', // leaf context row under Route 53
+      'Amazon Route 53 Private DNS', // promoted root row
+      'Amazon S3',
+    ]);
+  });
+
+  it('the duplicated leaf is not expandable, but the promoted root is', () => {
+    const table = renderTable(fromProducts(productsFixture()));
+    expandRow(table, 1);
+    // Row 3 is the leaf instance under Amazon Route 53: no expand toggle.
+    expect(table.findExpandToggle(3)).toBeNull();
+    // Row 4 is the promoted root: expandable, revealing its features.
+    expect(table.findExpandToggle(4)).not.toBeNull();
+    expandRow(table, 4);
+    expect(rowNames(table)).toContain('Geolocation Routing');
+  });
+
+  it('features of a sub-service stay hidden until its promoted root row is expanded', () => {
+    const table = renderTable(fromProducts(productsFixture()));
+    expandRow(table, 1);
+    expect(rowNames(table)).not.toContain('Geolocation Routing');
+  });
+
+  it('expand all reveals every level of the two-layer hierarchy', () => {
+    const table = renderTable(fromProducts(productsFixture()));
+    const expandAll = createWrapper(table.getElement().parentElement as HTMLElement)
+      .findAllButtons()
+      .find(b => b.getElement().textContent === 'Expand all');
+    act(() => {
+      expandAll!.click();
+    });
+    const names = rowNames(table);
+    expect(names).toContain('Route 53 Domains');
+    expect(names).toContain('Geolocation Routing');
+    // Duplicated service appears exactly twice: leaf + root.
+    expect(names.filter(n => n === 'Amazon Route 53 Private DNS')).toHaveLength(2);
+  });
+
+  it('counts promoted child services in the header counter as top-level items', () => {
+    const rows = fromProducts(productsFixture());
+    const table = renderTable(rows);
+    // Three root rows: Amazon Route 53, promoted Private DNS, Amazon S3.
+    expect(table.findHeaderSlot()!.getElement().textContent).toContain('(3)');
+  });
+});
+
+describe('AvailabilityTable with API operation rows (API Operations tab regression)', () => {
+  const apiFixture: ApiService[] = [
+    {
+      sdkServiceName: 's3',
+      sdkServiceFullName: 'Amazon Simple Storage Service',
+      apis: [
+        {
+          apiName: 's3:GetObject',
+          apiAction: 'GetObject',
+          homepage: 'https://docs.aws.amazon.com/s3',
+          regionalAvailability: AVAILABLE,
+        },
+      ],
+    },
+  ];
+
+  it('renders service root rows and expands to operations', () => {
+    const table = renderTable(fromApiServices(apiFixture), 'API Operations');
+    expect(rowNames(table)).toEqual(['Amazon Simple Storage Service']);
+    expandRow(table, 1);
+    expect(rowNames(table)).toEqual(['Amazon Simple Storage Service', 'GetObject']);
+  });
+});
+
+describe('AvailabilityTable with CFN resource rows (CloudFormation Resources tab regression)', () => {
+  const cfnFixture: CfnResource[] = [
+    {
+      serviceName: 'EC2',
+      resourceTypes: [
+        {
+          resourceTypeName: 'AWS::EC2::Instance',
+          resourceTypeHomepage: 'https://docs.aws.amazon.com/ec2',
+          regionalAvailability: AVAILABLE,
+          resourceProperties: [
+            {
+              resourcePropertyName: 'InstanceType',
+              resourceConfigurations: [{ resourceConfigurationName: 't3.medium', regionalAvailability: AVAILABLE }],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it('renders and expands the full four-level hierarchy', () => {
+    const table = renderTable(fromCfnResources(cfnFixture), 'CloudFormation Resources');
+    expect(rowNames(table)).toEqual(['EC2']);
+    expandRow(table, 1);
+    expect(rowNames(table)).toEqual(['EC2', 'AWS::EC2::Instance']);
+    expandRow(table, 2);
+    expect(rowNames(table)).toContain('InstanceType');
+    expandRow(table, 3);
+    expect(rowNames(table)).toContain('t3.medium');
+  });
+});

--- a/source/website/app/mappers/regional-availability.mapper.test.ts
+++ b/source/website/app/mappers/regional-availability.mapper.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from 'vitest';
+import { ProductType, type Product } from '@capability-insights/shared/types/capability/product';
+import type { ApiService } from '@capability-insights/shared/types/capability/api';
+import type { CfnResource } from '@capability-insights/shared/types/capability/cfn';
+import { AvailabilityStatus } from '@capability-insights/shared/types/availability/availability-status';
+import { RegionalAvailabilityType } from '@capability-insights/shared/types/availability/regional-availability';
+import { fromProducts, fromApiServices, fromCfnResources } from './regional-availability.mapper';
+
+const AVAILABLE = { 'us-east-1': AvailabilityStatus.AVAILABLE };
+const PLANNING = { 'us-east-1': AvailabilityStatus.PLANNING };
+
+/** Mirrors the real Route 53 shape: a service whose children mix features and services. */
+function route53Fixture(): Product[] {
+  return [
+    {
+      productId: 'route-53',
+      productName: 'Amazon Route 53',
+      productType: ProductType.SERVICE,
+      homepage: 'https://aws.amazon.com/route53/',
+      regionalAvailability: AVAILABLE,
+      launchDates: { 'us-east-1': '2010-12-05' },
+      childProducts: [
+        {
+          productId: 'route-53-domains',
+          productName: 'Route 53 Domains',
+          productType: ProductType.FEATURE,
+          regionalAvailability: AVAILABLE,
+        },
+        {
+          productId: 'route-53-resolver-endpoints',
+          productName: 'Route 53 Resolver Endpoints',
+          productType: ProductType.SERVICE,
+          homepage: 'https://aws.amazon.com/route53/resolver/',
+          regionalAvailability: PLANNING,
+          childProducts: [
+            {
+              productId: 'doh-endpoints',
+              productName: 'DoH Endpoints',
+              productType: ProductType.FEATURE,
+              regionalAvailability: AVAILABLE,
+            },
+            {
+              productId: 'ipv6-inbound',
+              productName: 'Support IPv6-only Inbound Endpoints',
+              productType: ProductType.FEATURE,
+              regionalAvailability: PLANNING,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+describe('fromProducts', () => {
+  it('returns an empty array for empty input', () => {
+    expect(fromProducts([])).toEqual([]);
+  });
+
+  it('maps a childless top-level service to a single root row', () => {
+    const rows = fromProducts([
+      {
+        productId: 's3',
+        productName: 'Amazon S3',
+        productType: ProductType.SERVICE,
+        regionalAvailability: AVAILABLE,
+      },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 's3',
+      parentId: null,
+      name: 'Amazon S3',
+      regionalAvailabilityType: RegionalAvailabilityType.SERVICE,
+    });
+  });
+
+  it('maps feature children under their parent, keeping their productId as row id', () => {
+    const rows = fromProducts(route53Fixture());
+    const domains = rows.find(r => r.name === 'Route 53 Domains');
+    expect(domains).toMatchObject({
+      id: 'route-53-domains',
+      parentId: 'route-53',
+      regionalAvailabilityType: RegionalAvailabilityType.FEATURE,
+    });
+  });
+
+  it('emits a child service twice: as a leaf under its parent and as its own root row', () => {
+    const rows = fromProducts(route53Fixture());
+    const instances = rows.filter(r => r.name === 'Route 53 Resolver Endpoints');
+    expect(instances).toHaveLength(2);
+
+    const leaf = instances.find(r => r.parentId === 'route-53');
+    const root = instances.find(r => r.parentId === null);
+
+    // Leaf instance under the parent uses a synthetic id so row ids stay unique.
+    expect(leaf).toMatchObject({
+      id: 'route-53:route-53-resolver-endpoints',
+      regionalAvailabilityType: RegionalAvailabilityType.SERVICE,
+    });
+    // Root instance keeps the canonical productId so its children can attach to it.
+    expect(root).toMatchObject({ id: 'route-53-resolver-endpoints' });
+  });
+
+  it('attaches grandchild features to the promoted root row, not to the leaf instance', () => {
+    const rows = fromProducts(route53Fixture());
+    const doh = rows.find(r => r.name === 'DoH Endpoints');
+    const ipv6 = rows.find(r => r.name === 'Support IPv6-only Inbound Endpoints');
+    expect(doh?.parentId).toBe('route-53-resolver-endpoints');
+    expect(ipv6?.parentId).toBe('route-53-resolver-endpoints');
+    // Nothing is parented to the synthetic leaf id.
+    expect(rows.some(r => r.parentId === 'route-53:route-53-resolver-endpoints')).toBe(false);
+  });
+
+  it('copies availability data onto both instances of a duplicated child service', () => {
+    const rows = fromProducts(route53Fixture());
+    const instances = rows.filter(r => r.name === 'Route 53 Resolver Endpoints');
+    for (const instance of instances) {
+      expect(instance.regionalAvailability).toEqual(PLANNING);
+      expect(instance.homepageUrl).toBe('https://aws.amazon.com/route53/resolver/');
+    }
+  });
+
+  it('produces globally unique row ids', () => {
+    const rows = fromProducts(route53Fixture());
+    const ids = rows.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('never produces more than two visual levels (every parentId points at a root row)', () => {
+    const rows = fromProducts(route53Fixture());
+    const byId = new Map(rows.map(r => [r.id, r]));
+    for (const row of rows) {
+      if (row.parentId === null) continue;
+      const parent = byId.get(row.parentId);
+      expect(parent, `parent of ${row.id} must exist in the row set`).toBeDefined();
+      expect(parent?.parentId, `parent of ${row.id} must be a root row`).toBeNull();
+    }
+  });
+
+  it('promotes a childless child service to a root row as well', () => {
+    const rows = fromProducts([
+      {
+        productId: 'dynamodb',
+        productName: 'Amazon DynamoDB',
+        productType: ProductType.SERVICE,
+        regionalAvailability: AVAILABLE,
+        childProducts: [
+          {
+            productId: 'dax',
+            productName: 'Amazon DynamoDB Accelerator',
+            productType: ProductType.SERVICE,
+            regionalAvailability: AVAILABLE,
+          },
+        ],
+      },
+    ]);
+    const instances = rows.filter(r => r.name === 'Amazon DynamoDB Accelerator');
+    expect(instances.map(r => ({ id: r.id, parentId: r.parentId }))).toEqual(
+      expect.arrayContaining([
+        { id: 'dynamodb:dax', parentId: 'dynamodb' },
+        { id: 'dax', parentId: null },
+      ]),
+    );
+  });
+
+  it('handles services nested more than three levels deep by promoting recursively', () => {
+    const rows = fromProducts([
+      {
+        productId: 'a',
+        productName: 'A',
+        productType: ProductType.SERVICE,
+        regionalAvailability: AVAILABLE,
+        childProducts: [
+          {
+            productId: 'b',
+            productName: 'B',
+            productType: ProductType.SERVICE,
+            regionalAvailability: AVAILABLE,
+            childProducts: [
+              {
+                productId: 'c',
+                productName: 'C',
+                productType: ProductType.SERVICE,
+                regionalAvailability: AVAILABLE,
+                childProducts: [
+                  {
+                    productId: 'd',
+                    productName: 'D',
+                    productType: ProductType.FEATURE,
+                    regionalAvailability: AVAILABLE,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    // Every service becomes a root row; deepest feature hangs off its direct parent.
+    expect(rows.filter(r => r.parentId === null).map(r => r.id)).toEqual(['a', 'b', 'c']);
+    expect(rows.find(r => r.id === 'd')?.parentId).toBe('c');
+    // Leaf context rows exist for each nested service.
+    expect(rows.find(r => r.id === 'a:b')?.parentId).toBe('a');
+    expect(rows.find(r => r.id === 'b:c')?.parentId).toBe('b');
+    const ids = rows.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps root-level ordering: promoted services appear after their former parent', () => {
+    const rows = fromProducts(route53Fixture());
+    const rootIds = rows.filter(r => r.parentId === null).map(r => r.id);
+    expect(rootIds).toEqual(['route-53', 'route-53-resolver-endpoints']);
+  });
+});
+
+describe('fromApiServices (API Operations tab regression)', () => {
+  const fixture: ApiService[] = [
+    {
+      sdkServiceName: 's3',
+      sdkServiceFullName: 'Amazon Simple Storage Service',
+      productName: 'Amazon S3',
+      apis: [
+        {
+          apiName: 's3:GetObject',
+          apiAction: 'GetObject',
+          homepage: 'https://docs.aws.amazon.com/s3/GetObject',
+          regionalAvailability: AVAILABLE,
+        },
+        {
+          apiName: 's3:PutObject',
+          apiAction: 'PutObject',
+          homepage: 'https://docs.aws.amazon.com/s3/PutObject',
+          regionalAvailability: PLANNING,
+        },
+      ],
+    },
+  ];
+
+  it('maps services to prefixed root rows and operations to child rows', () => {
+    const rows = fromApiServices(fixture);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      id: 'svc-s3',
+      parentId: null,
+      name: 'Amazon Simple Storage Service',
+      regionalAvailabilityType: RegionalAvailabilityType.SDK_SERVICE,
+      sdkServiceName: 's3',
+      productName: 'Amazon S3',
+    });
+    expect(rows[1]).toMatchObject({
+      id: 's3:GetObject',
+      parentId: 'svc-s3',
+      name: 'GetObject',
+      regionalAvailabilityType: RegionalAvailabilityType.OPERATION,
+      regionalAvailability: AVAILABLE,
+    });
+    expect(rows[2]).toMatchObject({ id: 's3:PutObject', parentId: 'svc-s3' });
+  });
+
+  it('produces exactly two levels with unique ids', () => {
+    const rows = fromApiServices(fixture);
+    const ids = rows.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const byId = new Map(rows.map(r => [r.id, r]));
+    for (const row of rows) {
+      if (row.parentId !== null) expect(byId.get(row.parentId)?.parentId).toBeNull();
+    }
+  });
+});
+
+describe('fromCfnResources (CloudFormation Resources tab regression)', () => {
+  const fixture: CfnResource[] = [
+    {
+      serviceName: 'EC2',
+      resourceTypes: [
+        {
+          resourceTypeName: 'AWS::EC2::Instance',
+          resourceTypeHomepage: 'https://docs.aws.amazon.com/ec2-instance',
+          regionalAvailability: AVAILABLE,
+          resourceProperties: [
+            {
+              resourcePropertyName: 'InstanceType',
+              resourceConfigurations: [
+                {
+                  resourceConfigurationName: 't3.medium',
+                  regionalAvailability: AVAILABLE,
+                  stacks: ['my-stack'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it('maps the full four-level hierarchy: service, resource type, property, configuration', () => {
+    const rows = fromCfnResources(fixture);
+    expect(rows.map(r => ({ id: r.id, parentId: r.parentId }))).toEqual([
+      { id: 'cfn-EC2', parentId: null },
+      { id: 'cfn-EC2-AWS::EC2::Instance', parentId: 'cfn-EC2' },
+      { id: 'cfn-EC2-AWS::EC2::Instance-InstanceType', parentId: 'cfn-EC2-AWS::EC2::Instance' },
+      {
+        id: 'cfn-EC2-AWS::EC2::Instance-InstanceType-t3.medium',
+        parentId: 'cfn-EC2-AWS::EC2::Instance-InstanceType',
+      },
+    ]);
+  });
+
+  it('preserves row types and stack attribution', () => {
+    const rows = fromCfnResources(fixture);
+    expect(rows.map(r => r.regionalAvailabilityType)).toEqual([
+      RegionalAvailabilityType.SERVICE,
+      RegionalAvailabilityType.RESOURCE_TYPE,
+      RegionalAvailabilityType.PROPERTY,
+      RegionalAvailabilityType.CONFIGURATION,
+    ]);
+    expect(rows[3].stacks).toEqual(['my-stack']);
+  });
+
+  it('handles resource types without properties', () => {
+    const rows = fromCfnResources([
+      {
+        serviceName: 'SQS',
+        resourceTypes: [
+          {
+            resourceTypeName: 'AWS::SQS::Queue',
+            resourceTypeHomepage: 'https://docs.aws.amazon.com/sqs-queue',
+            regionalAvailability: AVAILABLE,
+          },
+        ],
+      },
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({ id: 'cfn-SQS-AWS::SQS::Queue', parentId: 'cfn-SQS' });
+  });
+});

--- a/source/website/app/mappers/regional-availability.mapper.ts
+++ b/source/website/app/mappers/regional-availability.mapper.ts
@@ -14,14 +14,19 @@ import { RegionalAvailabilityType } from '@capability-insights/shared/types/avai
  * Flattens the nested childProducts structure into a flat array
  * using id/parentId references.
  *
+ * The table only ever shows two levels (parent and child). Child products of
+ * type SERVICE can have their own children, so they are emitted twice: once as
+ * a leaf child under their parent (for context, with a synthetic id to keep
+ * row ids unique), and once as a root row with their own children underneath.
+ *
  * @param products - Raw product data from the client
  * @returns Flat array of rows with availability status per region
  */
 export function fromProducts(products: Product[]): ProductAvailability[] {
   const rows: ProductAvailability[] = [];
 
-  const toRow = (product: Product, parentId: string | null): ProductAvailability => ({
-    id: product.productId,
+  const toRow = (product: Product, parentId: string | null, id?: string): ProductAvailability => ({
+    id: id ?? product.productId,
     parentId,
     name: product.productName,
     productType: product.productType,
@@ -32,11 +37,23 @@ export function fromProducts(products: Product[]): ProductAvailability[] {
     regionalAvailability: product.regionalAvailability,
   });
 
-  for (const p of products) {
-    rows.push(toRow(p, null));
-    for (const child of p.childProducts ?? []) {
-      rows.push(toRow(child, p.productId));
+  const emitTwoLevels = (parent: Product): void => {
+    rows.push(toRow(parent, null));
+    for (const child of parent.childProducts ?? []) {
+      if (child.productType === ProductType.SERVICE) {
+        // Leaf child row for context under its parent; the synthetic id keeps
+        // it distinct from the root row emitted below.
+        rows.push(toRow(child, parent.productId, `${parent.productId}:${child.productId}`));
+        // Root row for the child service, with its own children underneath.
+        emitTwoLevels(child);
+      } else {
+        rows.push(toRow(child, parent.productId));
+      }
     }
+  };
+
+  for (const p of products) {
+    emitTwoLevels(p);
   }
 
   return rows;

--- a/source/website/package.json
+++ b/source/website/package.json
@@ -7,6 +7,7 @@
     "clean": "rm -rf dist dist_build .react-router",
     "package": "cp -r dist/. ../../deployment/dist/website/",
     "dev": "react-router dev",
+    "test": "vitest run",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc"
   },
@@ -23,8 +24,13 @@
   },
   "devDependencies": {
     "@react-router/dev": "7.13.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.1",
     "vite": "^7.1.7",
     "vite-tsconfig-paths": "^5.1.4"
   }

--- a/source/website/vitest.config.ts
+++ b/source/website/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['app/**/*.test.{ts,tsx}'],
+    exclude: ['node_modules/**', 'dist/**', 'dist_build/**'],
+  },
+});

--- a/source/website/vitest.setup.ts
+++ b/source/website/vitest.setup.ts
@@ -1,4 +1,13 @@
 import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Testing Library only auto-registers cleanup when vitest globals are enabled.
+// Without it, mounted components keep scheduling React work after the jsdom
+// environment is torn down ("window is not defined" uncaught exceptions).
+afterEach(() => {
+  cleanup();
+});
 
 // Cloudscape components rely on browser APIs that jsdom does not implement.
 if (typeof globalThis.ResizeObserver === 'undefined') {

--- a/source/website/vitest.setup.ts
+++ b/source/website/vitest.setup.ts
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom/vitest';
+
+// Cloudscape components rely on browser APIs that jsdom does not implement.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+if (typeof window !== 'undefined' && typeof window.matchMedia === 'undefined') {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}


### PR DESCRIPTION
## Problem

Services nested under another service (e.g. Route 53 → Private DNS) never
showed their features — the dashboard only rendered two levels. Separately,
OR filter queries behaved as AND and matched almost nothing.

## Fix

- Sub-services now appear twice, matching builder.aws.com: as a context row
  under their parent, and as their own expandable root row with their
  features. The table stays two levels deep.
- The filtering function respects `query.operation` (or/and).

## Testing

- New vitest setup for the website workspace (previously untested).
- 41 unit tests: mappers, filter semantics (AND/OR, ancestor cascade,
  inheritance), and table rendering/expansion — including regression
  coverage for the API Operations and CloudFormation Resources tabs.
