### PR TITLE
fix(lambda): merge nested childProducts by id across source folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/source/lambda/data-fetch/merge/merge-json.test.ts
+++ b/source/lambda/data-fetch/merge/merge-json.test.ts
@@ -82,6 +82,112 @@ describe('mergeJson', () => {
         'eu-west-1': 'Available',
       });
     });
+    it('deduplicates grandchild products present in multiple sources (self-recursive childProducts)', () => {
+      // A sub-service (SERVICE nested under a SERVICE) with its own features
+      // can appear in multiple source folders and must merge into one record.
+      const makeChunk = (regions: Record<string, string>, childRegions: Record<string, string>) =>
+        JSON.stringify([
+          {
+            productId: 'parent-service',
+            productName: 'Parent Service',
+            productType: 'SERVICE',
+            regionalAvailability: regions,
+            childProducts: [
+              {
+                productId: 'sub-service',
+                productName: 'Sub Service',
+                productType: 'SERVICE',
+                regionalAvailability: regions,
+                childProducts: [
+                  {
+                    productId: 'nested-feature',
+                    productName: 'Nested Feature',
+                    productType: 'FEATURE',
+                    regionalAvailability: childRegions,
+                    launchDates: Object.fromEntries(
+                      Object.entries(childRegions)
+                        .filter(([, v]) => v === 'Planned')
+                        .map(([k]) => [k, '2099 Q1']),
+                    ),
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+
+      const chunk1 = makeChunk({ 'us-east-1': 'Available' }, { 'us-east-1': 'Available' });
+      const chunk2 = makeChunk({ 'eu-west-1': 'Available' }, { 'eu-west-1': 'Planned' });
+
+      const result = JSON.parse(
+        mergeJson([chunk1, chunk2], p => p.productId, [{ key: 'childProducts', getId: c => c.productId }]),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].childProducts).toHaveLength(1);
+
+      // The grandchild must appear exactly once, with availability merged from both sources.
+      const grandchildren = result[0].childProducts[0].childProducts;
+      expect(grandchildren).toHaveLength(1);
+      expect(grandchildren[0].regionalAvailability).toEqual({
+        'us-east-1': 'Available',
+        'eu-west-1': 'Planned',
+      });
+      expect(grandchildren[0].launchDates).toEqual({ 'eu-west-1': '2099 Q1' });
+    });
+
+    it('deduplicates products by id at arbitrary nesting depth', () => {
+      const makeChunk = (region: string) =>
+        JSON.stringify([
+          {
+            productId: 'l1',
+            productName: 'Level 1',
+            productType: 'SERVICE',
+            regionalAvailability: { [region]: 'Available' },
+            childProducts: [
+              {
+                productId: 'l2',
+                productName: 'Level 2',
+                productType: 'SERVICE',
+                regionalAvailability: { [region]: 'Available' },
+                childProducts: [
+                  {
+                    productId: 'l3',
+                    productName: 'Level 3',
+                    productType: 'SERVICE',
+                    regionalAvailability: { [region]: 'Available' },
+                    childProducts: [
+                      {
+                        productId: 'l4',
+                        productName: 'Level 4',
+                        productType: 'FEATURE',
+                        regionalAvailability: { [region]: 'Available' },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+
+      const result = JSON.parse(
+        mergeJson([makeChunk('us-east-1'), makeChunk('eu-west-1')], p => p.productId, [
+          { key: 'childProducts', getId: c => c.productId },
+        ]),
+      );
+
+      let level = result;
+      for (const id of ['l1', 'l2', 'l3', 'l4']) {
+        expect(level).toHaveLength(1);
+        expect(level[0].productId).toBe(id);
+        expect(level[0].regionalAvailability).toEqual({
+          'us-east-1': 'Available',
+          'eu-west-1': 'Available',
+        });
+        level = level[0].childProducts;
+      }
+    });
   });
 
   describe('apis', () => {

--- a/source/lambda/data-fetch/merge/merge-json.ts
+++ b/source/lambda/data-fetch/merge/merge-json.ts
@@ -59,12 +59,13 @@ function deepMerge<T>(existing: T, incoming: T, childConfigs?: ChildMergeConfig[
     if (Array.isArray(incomingValue) && Array.isArray(existingValue)) {
       const config = childConfigs?.find(c => c.key === key);
       if (config) {
-        // Deduplicate this child array and pass remaining configs for deeper levels
-        const remainingConfigs = childConfigs?.filter(c => c.key !== key);
+        // Deduplicate this child array. Pass ALL configs down so self-recursive
+        // structures (e.g. childProducts nested inside childProducts) keep
+        // merging by id at every depth instead of concatenating duplicates.
         mergedItem[key] = mergeArrayById(
           [...existingValue, ...incomingValue],
           config.getId as (item: unknown) => string,
-          remainingConfigs,
+          childConfigs,
         );
       } else {
         // Plain array — just concatenate


### PR DESCRIPTION
## Problem

The DataFetch merge deduplicated products and their direct children by id,
but dropped the child config when recursing — so grandchild `childProducts`
arrays from multiple source folders were concatenated instead of merged.
Multi-folder deployments produced duplicate sub-service features with
region availability split across the copies. Hidden until #46 made those
rows visible.

## Fix

`deepMerge` now passes all child configs down when merging nested arrays,
so self-recursive structures (`childProducts` inside `childProducts`)
merge by id at every depth. Distinct-key structures (APIs, CFN resources)
are unaffected — config lookup is by key and their merged output is
unchanged.

## Testing

- Two new unit tests written first to reproduce the bug (grandchild
  duplication, arbitrary-depth dedup) — failed before the fix, pass after.
- Existing merge tests for regions/products/apis/cfn pass unchanged.
- Verified against real multi-folder data: 0 duplicates in the merged
  tree, every source node present, all region maps equal to the union
  of their sources.
