### PR TITLE
fix(constructs): let CloudFormation auto-generate IAM role names (#45)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/source/constructs/lib/stacks/__snapshots__/policy-enforcer-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/policy-enforcer-stack.test.ts.snap
@@ -208,9 +208,6 @@ exports[`CloudFormation template matches snapshot 1`] = `
             "PolicyName": "BulkRefreshAccess",
           },
         ],
-        "RoleName": {
-          "Fn::Sub": "CapabilityInsightsPolicyEnforcerBulkRefreshRole-\${AWS::Region}",
-        },
       },
       "Type": "AWS::IAM::Role",
     },
@@ -332,9 +329,6 @@ exports[`CloudFormation template matches snapshot 1`] = `
             "PolicyName": "PolicyEnforcerIamManagement",
           },
         ],
-        "RoleName": {
-          "Fn::Sub": "CapabilityInsightsPolicyEnforcerIamHelperRole-\${AWS::Region}",
-        },
       },
       "Type": "AWS::IAM::Role",
     },

--- a/source/constructs/lib/stacks/__snapshots__/usage-analysis-stack.test.ts.snap
+++ b/source/constructs/lib/stacks/__snapshots__/usage-analysis-stack.test.ts.snap
@@ -371,9 +371,6 @@ exports[`CloudFormation template matches snapshot 1`] = `
             "PolicyName": "S3WriteAccess",
           },
         ],
-        "RoleName": {
-          "Fn::Sub": "CapabilityInsightsCloudFormationAnalyzerRole-\${AWS::Region}",
-        },
       },
       "Type": "AWS::IAM::Role",
     },
@@ -596,9 +593,6 @@ exports[`CloudFormation template matches snapshot 1`] = `
             "PolicyName": "S3WriteAccess",
           },
         ],
-        "RoleName": {
-          "Fn::Sub": "CapabilityInsightsCloudTrailAnalyzerRole-\${AWS::Region}",
-        },
       },
       "Type": "AWS::IAM::Role",
     },
@@ -870,9 +864,6 @@ def lambda_handler(event, context):
             "PolicyName": "LakeFormationBootstrap",
           },
         ],
-        "RoleName": {
-          "Fn::Sub": "CapabilityInsightsLakeFormationBootstrapLambdaRole-\${AWS::Region}",
-        },
       },
       "Type": "AWS::IAM::Role",
     },
@@ -1031,9 +1022,6 @@ def lambda_handler(event, context):
             "PolicyName": "S3WriteUsedFiles",
           },
         ],
-        "RoleName": {
-          "Fn::Sub": "CapabilityInsightsUsageDecoratorRole-\${AWS::Region}",
-        },
       },
       "Type": "AWS::IAM::Role",
     },

--- a/source/constructs/lib/stacks/policy-enforcer-stack.ts
+++ b/source/constructs/lib/stacks/policy-enforcer-stack.ts
@@ -131,10 +131,9 @@ export class PolicyEnforcerStack extends cdk.Stack {
     this.iamHelperLambdaName = iamHelperLambdaName;
 
     const iamHelperRole = new iam.Role(this, `${iamHelperLambdaName}Role`, {
-      // The logical ID is pinned below via overrideLogicalId so this
-      // hardcoded physical name stays consistent with it. See the
-      // DynamoDB table above for the reasoning.
-      roleName: cdk.Fn.sub(`${iamHelperLambdaName}Role-\${AWS::Region}`),
+      // Logical ID is pinned via overrideLogicalId (below) to keep it stable
+      // across deploys. The physical role name is left for CloudFormation to
+      // generate — no need to force one (auto-names are always within limits).
       description:
         'Execution role for the Policy Enforcer IAM Helper Lambda. Scoped to PolicyEnforcer-* managed policies only.',
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
@@ -211,7 +210,6 @@ export class PolicyEnforcerStack extends cdk.Stack {
 
     const refreshRole = new iam.Role(this, `${refreshLambdaName}Role`, {
       // Logical ID pinned below — see the IAM Helper role above for the rationale.
-      roleName: cdk.Fn.sub(`${refreshLambdaName}Role-\${AWS::Region}`),
       description: 'Execution role for the Policy Enforcer bulk refresh Lambda.',
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
       managedPolicies: [

--- a/source/constructs/lib/stacks/usage-analysis-stack.ts
+++ b/source/constructs/lib/stacks/usage-analysis-stack.ts
@@ -180,7 +180,6 @@ export class UsageAnalysisStack extends cdk.Stack {
     // CloudTrail Analyzer Lambda
     const cloudtrailAnalyzerLambdaName = `${prefix}CloudTrailAnalyzer`;
     const cloudtrailAnalyzerRole = new iam.CfnRole(this, `${cloudtrailAnalyzerLambdaName}Role`, {
-      roleName: cdk.Fn.sub(`${cloudtrailAnalyzerLambdaName}Role-\${AWS::Region}`),
       assumeRolePolicyDocument: {
         Version: '2012-10-17',
         Statement: [
@@ -315,9 +314,7 @@ export class UsageAnalysisStack extends cdk.Stack {
     // deploy` directly, not `cdk deploy`).
     const lakeFormationBootstrapLambdaName = `${prefix}LakeFormationBootstrapLambda`;
     const lakeFormationBootstrapRoleName = `${prefix}LakeFormationBootstrapLambdaRole`;
-    const lakeFormationBootstrapRoleNameFn = cdk.Fn.sub(`${lakeFormationBootstrapRoleName}-\${AWS::Region}`);
     const lakeFormationBootstrapRole = new iam.CfnRole(this, lakeFormationBootstrapRoleName, {
-      roleName: lakeFormationBootstrapRoleNameFn,
       assumeRolePolicyDocument: {
         Version: '2012-10-17',
         Statement: [
@@ -468,7 +465,6 @@ def lambda_handler(event, context):
     // which is only accessible from within the configured VPC.
     const cloudformationAnalyzerLambdaName = `${prefix}CloudFormationAnalyzer`;
     const cloudformationAnalyzerRole = new iam.CfnRole(this, `${cloudformationAnalyzerLambdaName}Role`, {
-      roleName: cdk.Fn.sub(`${cloudformationAnalyzerLambdaName}Role-\${AWS::Region}`),
       assumeRolePolicyDocument: {
         Version: '2012-10-17',
         Statement: [
@@ -543,7 +539,6 @@ def lambda_handler(event, context):
     // to the same bucket for the UI to consume.
     const usageDecoratorLambdaName = `${prefix}UsageDecorator`;
     const usageDecoratorRole = new iam.CfnRole(this, `${usageDecoratorLambdaName}Role`, {
-      roleName: cdk.Fn.sub(`${usageDecoratorLambdaName}Role-\${AWS::Region}`),
       assumeRolePolicyDocument: {
         Version: '2012-10-17',
         Statement: [

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capability-insights/constructs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "Apache-2.0",
   "private": true,
   "main": "dist/lib/index.js",

--- a/source/shared/package.json
+++ b/source/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capability-insights/shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary (required)

Stops forcing explicit IAM role names and lets CloudFormation auto-generate them — the fix a reviewer asked for after hitting a 64-char IAM role-name overflow deploying to MEL (issue #45). This removes work the framework already does for us, and deletes the overflow problem class rather than working around it.

## Details (required)

Six IAM roles set an explicit `roleName` with a `-${AWS::Region}` suffix (the suffix existed to avoid cross-region name collisions). CloudFormation already guarantees unique, within-limit role names when you omit `roleName`, so the forced names were redundant — and for the longest region codes (`ap-northeast-1`, `ap-southeast-3`) `CapabilityInsightsLakeFormationBootstrapLambdaRole-<region>` reached 65 chars, over the 64-char limit, failing the deploy.

Two roles in `usage-analysis-stack.ts` (`AnalysisStateMachineRole`, `AnalysisScheduleRole`) already omit `roleName`; this brings the rest in line:

- **usage-analysis-stack.ts** — drop `roleName` on `cloudtrailAnalyzerRole`, `lakeFormationBootstrapRole`, `cloudformationAnalyzerRole`, `usageDecoratorRole`.
- **policy-enforcer-stack.ts** — drop `roleName` on the IAM Helper and bulk-refresh execution roles.

Every consumer references these roles by ARN (`Fn::GetAtt ...Arn` / `.roleArn`) or by pinned logical ID — never by physical name — so nothing downstream changes. Logical IDs and Lambda **function** names are unchanged, and the Policy Enforcer `PolicyEnforcer-*` managed-policy authorization boundary is untouched.

## Testing (required)

- [x] Unit tests

**How did you test this?**

`tsc --noEmit`, `eslint`, and `prettier --check` clean on both changed files. `npx vitest run` in `source/constructs`: 5 files, 29 tests pass. Snapshots regenerated for the two stacks — the diff is purely the removal of the 6 `RoleName` properties (no logical-ID or dependency churn). Two independent reviews confirmed no consumer depends on the physical role name and the security boundary is intact.

⚠️ **Deploy note:** removing an explicit `RoleName` is a CloudFormation **replacement** (create new auto-named role → repoint consumers via `GetAtt`/`DependsOn` → delete old). It's safe here — these are execution/bootstrap roles with no external ARN references, and in regions where the old name overflowed the stack couldn't deploy at all, so it's a first successful deploy there rather than a replacement.