### PR TITLE
fix(website): Export filtered data when property filter is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/source/website/app/components/availability/availability-table.tsx
+++ b/source/website/app/components/availability/availability-table.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import Table from '@cloudscape-design/components/table';
 import PropertyFilter from '@cloudscape-design/components/property-filter';
@@ -20,6 +20,7 @@ import {
   TablePreferences,
 } from './availability-table-properties';
 import { deriveTimeframeOptions } from '~/utils/planning-timeframe';
+import { generateCsv, generateJson, downloadBlob } from '~/utils/export-utils';
 
 interface AvailabilityTableProps<T extends RegionalAvailability> {
   title: string;
@@ -92,6 +93,45 @@ export default function AvailabilityTable<T extends RegionalAvailability>({
   const actionsRef = useRef(actions);
   actionsRef.current = actions;
   const prevQueryRef = useRef(query);
+
+  // Export all filtered items including ancestor rows to mirror the UI tree
+  const filteredItems = useMemo(() => {
+    if (!hasActiveFilter) return regionalAvailability;
+    const byId = new Map(regionalAvailability.map(i => [i.id, i]));
+    const matched = regionalAvailability.filter(item => filteringFunction(item, query));
+    const matchedIds = new Set(matched.map(item => item.id));
+    for (const item of matched) {
+      let parentId = item.parentId;
+      while (parentId && !matchedIds.has(parentId)) {
+        matchedIds.add(parentId);
+        const parent = byId.get(parentId);
+        parentId = parent?.parentId ?? null;
+      }
+    }
+    return regionalAvailability.filter(item => matchedIds.has(item.id));
+  }, [hasActiveFilter, regionalAvailability, filteringFunction, query]);
+
+  const handleExport = useCallback(
+    (format: 'json' | 'csv') => {
+      if (!hasActiveFilter) {
+        const url = format === 'json' ? downloadUrls.json : downloadUrls.csv;
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = '';
+        a.click();
+        return;
+      }
+      const safeTitle = title.toLowerCase().replace(/\s+/g, '-');
+      if (format === 'csv') {
+        const csv = generateCsv(filteredItems, regions);
+        downloadBlob(csv, `${safeTitle}-filtered.csv`, 'text/csv;charset=utf-8');
+      } else {
+        const json = generateJson(filteredItems, regions);
+        downloadBlob(json, `${safeTitle}-filtered.json`, 'application/json');
+      }
+    },
+    [hasActiveFilter, downloadUrls, filteredItems, regions, title],
+  );
 
   useEffect(() => {
     if (query === prevQueryRef.current) return;
@@ -176,13 +216,7 @@ export default function AvailabilityTable<T extends RegionalAvailability>({
                   { id: 'json', text: 'Download as JSON' },
                   { id: 'csv', text: 'Download as CSV' },
                 ]}
-                onItemClick={({ detail }) => {
-                  const url = detail.id === 'json' ? downloadUrls.json : downloadUrls.csv;
-                  const a = document.createElement('a');
-                  a.href = url;
-                  a.download = '';
-                  a.click();
-                }}
+                onItemClick={({ detail }) => handleExport(detail.id as 'json' | 'csv')}
                 ariaLabel={`Export ${title}`}
               >
                 Export

--- a/source/website/app/utils/export-utils.test.ts
+++ b/source/website/app/utils/export-utils.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RegionalAvailabilityType,
+  type RegionalAvailability,
+} from '@capability-insights/shared/types/availability/regional-availability';
+import type { Region } from '@capability-insights/shared/types/capability/region';
+import { generateCsv, generateJson } from './export-utils';
+
+const regions: Region[] = [
+  {
+    Region: 'us-east-1',
+    RegionLongName: 'US East (N. Virginia)',
+    Partition: 'aws',
+    RegionStatus: 'available',
+    RequireRegionOptIn: false,
+  },
+  {
+    Region: 'eu-west-1',
+    RegionLongName: 'Europe (Ireland)',
+    Partition: 'aws',
+    RegionStatus: 'available',
+    RequireRegionOptIn: false,
+  },
+];
+
+function makeItem(overrides: Partial<RegionalAvailability> = {}): RegionalAvailability {
+  return {
+    id: 'item-1',
+    parentId: null,
+    name: 'Amazon S3',
+    regionalAvailabilityType: RegionalAvailabilityType.SERVICE,
+    regionalAvailability: { 'us-east-1': 'Available' as never, 'eu-west-1': 'Available' as never },
+    ...overrides,
+  };
+}
+
+describe('generateCsv', () => {
+  it('generates correct headers and data rows', () => {
+    const items = [makeItem()];
+    const csv = generateCsv(items, regions);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('Name,Type,us-east-1,eu-west-1');
+    expect(lines[1]).toBe('Amazon S3,Service,Available,Available');
+  });
+
+  it('handles empty items array', () => {
+    const csv = generateCsv([], regions);
+    expect(csv).toBe('Name,Type,us-east-1,eu-west-1');
+  });
+
+  it('escapes values containing commas', () => {
+    const items = [makeItem({ name: 'Service, Inc.' })];
+    const csv = generateCsv(items, regions);
+    const lines = csv.split('\n');
+    expect(lines[1]).toContain('"Service, Inc."');
+  });
+
+  it('escapes values containing double quotes', () => {
+    const items = [makeItem({ name: 'Say "Hello"' })];
+    const csv = generateCsv(items, regions);
+    const lines = csv.split('\n');
+    expect(lines[1]).toContain('"Say ""Hello"""');
+  });
+
+  it('escapes values containing newlines', () => {
+    const items = [makeItem({ name: 'Line1\nLine2' })];
+    const csv = generateCsv(items, regions);
+    const dataRow = csv.split('\n').slice(1).join('\n');
+    expect(dataRow).toContain('"Line1\nLine2"');
+  });
+
+  it('outputs empty string for missing region availability', () => {
+    const items = [makeItem({ regionalAvailability: { 'us-east-1': 'Available' as never } })];
+    const csv = generateCsv(items, regions);
+    const lines = csv.split('\n');
+    expect(lines[1]).toBe('Amazon S3,Service,Available,');
+  });
+
+  it('handles items with no regionalAvailability', () => {
+    const items = [makeItem({ regionalAvailability: undefined })];
+    const csv = generateCsv(items, regions);
+    const lines = csv.split('\n');
+    expect(lines[1]).toBe('Amazon S3,Service,,');
+  });
+
+  it('generates multiple rows preserving order', () => {
+    const items = [
+      makeItem({ id: '1', name: 'First' }),
+      makeItem({ id: '2', name: 'Second' }),
+      makeItem({ id: '3', name: 'Third' }),
+    ];
+    const csv = generateCsv(items, regions);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(4);
+    expect(lines[1]).toContain('First');
+    expect(lines[2]).toContain('Second');
+    expect(lines[3]).toContain('Third');
+  });
+});
+
+describe('generateJson', () => {
+  it('generates correct structure with region columns', () => {
+    const items = [makeItem()];
+    const json = JSON.parse(generateJson(items, regions));
+    expect(json).toHaveLength(1);
+    expect(json[0]).toEqual({
+      name: 'Amazon S3',
+      type: RegionalAvailabilityType.SERVICE,
+      'us-east-1': 'Available',
+      'eu-west-1': 'Available',
+    });
+  });
+
+  it('handles empty items array', () => {
+    const json = JSON.parse(generateJson([], regions));
+    expect(json).toEqual([]);
+  });
+
+  it('uses null for missing region availability', () => {
+    const items = [makeItem({ regionalAvailability: { 'us-east-1': 'Available' as never } })];
+    const json = JSON.parse(generateJson(items, regions));
+    expect(json[0]['eu-west-1']).toBeNull();
+  });
+
+  it('uses null for all regions when regionalAvailability is undefined', () => {
+    const items = [makeItem({ regionalAvailability: undefined })];
+    const json = JSON.parse(generateJson(items, regions));
+    expect(json[0]['us-east-1']).toBeNull();
+    expect(json[0]['eu-west-1']).toBeNull();
+  });
+
+  it('preserves item order', () => {
+    const items = [makeItem({ id: '1', name: 'Alpha' }), makeItem({ id: '2', name: 'Beta' })];
+    const json = JSON.parse(generateJson(items, regions));
+    expect(json[0].name).toBe('Alpha');
+    expect(json[1].name).toBe('Beta');
+  });
+
+  it('produces valid parseable JSON', () => {
+    const items = [makeItem({ name: 'Special "chars" & <tags>' })];
+    expect(() => JSON.parse(generateJson(items, regions))).not.toThrow();
+  });
+});

--- a/source/website/app/utils/export-utils.ts
+++ b/source/website/app/utils/export-utils.ts
@@ -1,0 +1,40 @@
+import type { Region } from '@capability-insights/shared/types/capability/region';
+import type { RegionalAvailability } from '@capability-insights/shared/types/availability/regional-availability';
+
+function escapeCsvValue(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function generateCsv(items: RegionalAvailability[], regions: Region[]): string {
+  const headers = ['Name', 'Type', ...regions.map(r => r.Region)];
+  const rows = items.map(item => [
+    escapeCsvValue(item.name),
+    escapeCsvValue(item.regionalAvailabilityType ?? ''),
+    ...regions.map(r => escapeCsvValue(item.regionalAvailability?.[r.Region] ?? '')),
+  ]);
+  return [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+}
+
+export function generateJson(items: RegionalAvailability[], regions: Region[]): string {
+  const data = items.map(item => ({
+    name: item.name,
+    type: item.regionalAvailabilityType,
+    ...Object.fromEntries(regions.map(r => [r.Region, item.regionalAvailability?.[r.Region] ?? null])),
+  }));
+  return JSON.stringify(data, null, 2);
+}
+
+export function downloadBlob(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
+}


### PR DESCRIPTION

### Summary (required)
Fix table export (CSV/JSON) to respect active property filters instead of always downloading the full unfiltered dataset.

### Details (required)
Previously, the Export button always downloaded pre-generated static files from S3 regardless of any active property filters. Users expected the exported file to contain only the filtered rows visible in the table.
When a filter is active, the export now generates CSV/JSON client-side from the filtered dataset using Blob downloads. When no filter is active, the original S3 download path is preserved (faster for full data). Parent/ancestor rows are included in the filtered export to mirror the UI's expandable tree hierarchy.

### Testing (required)
Check all that apply:

[ *] Unit tests
[* ] Local development server
[ *] Full deployment
#### How did you test this?

- Ran npm run server and verified table renders correctly
- Applied property filters (Name, Type, Region) and confirmed exported CSV/JSON contains only matching rows + their parent rows
- Verified export without filters still downloads the full S3 file (unchanged behavior)
- Tested edge cases: filter matching only children (parent included in export), filter matching parent (children included), empty filter results
- Bumps version to 1.7.0.