### PR TITLE
Add static detector

### DIFF
--- a/scripts/static-detector/README.md
+++ b/scripts/static-detector/README.md
@@ -1,90 +1,86 @@
 # capabilities-detector
 
-Deterministically detect the **AWS services, CloudFormation resource types, and
-SDK API operations** a codebase depends on — by statically reading the code.
+Scans a codebase and tells you which AWS it uses: the services, the
+CloudFormation resource types, and the API operations. It reads the code
+statically, so there's no guessing and no runtime needed.
 
-**Fully static and offline:** no AWS credentials, no network calls, no deployed
-infrastructure. It reads files and writes a report of what the code uses.
+Static and offline. No AWS credentials, no network calls, nothing deployed. It
+reads files and writes a report. One Python file plus one data file, nothing to
+install.
 
-It is a single Python file plus one bundled data file. Nothing to install.
+## Setup
 
----
-
-## Setup (one folder, two files, zero installs)
+Two files in a folder, that's the whole install:
 
 ```
 capabilities-detector/
 ├── detect.py
-└── aws-api-universe.json.gz     # must sit next to detect.py
+└── aws-api-universe.json.gz     # keep this next to detect.py
 ```
 
-**Requirements: Python 3.8+ and nothing else** — no `pip install`, no
-credentials, no network.
+Needs Python 3.8+ and nothing else. No `pip install`, no credentials, no network.
 
 ```bash
 python3 detect.py /path/to/thing-to-scan
 ```
 
----
-
 ## Usage
 
-Same command each time; only the target changes.
+Same command every time, you just change the target.
 
-**Scan a code repo** (application code + CloudFormation/SAM/CDK/Terraform):
+Scan a code repo (app code + CloudFormation/SAM/CDK/Terraform):
 ```bash
 python3 detect.py /path/to/a/repo
 ```
 
-**Scan CloudTrail logs** (what actually ran — a `.json`, `.json.gz`, or a
-directory of them). `-` means "no repo, logs only":
+Scan CloudTrail logs (what actually ran). `-` means logs only, no repo:
 ```bash
 python3 detect.py - --cloudtrail /path/to/cloudtrail-log.json
 ```
 
-**Scan both at once** (code + runtime, one report):
+Scan both at once (code + runtime in one report):
 ```bash
 python3 detect.py /path/to/a/repo --cloudtrail /path/to/cloudtrail-log.json
 ```
 
-### Common flags
+### Flags
+
 ```bash
 python3 detect.py /repo --customer "Acme" --application "svc"  # tag the results
-python3 detect.py /repo --quiet                # hide the table
-python3 detect.py /repo --no-report            # don't write report files
-python3 detect.py /repo --no-payload           # skip the shareable results payload
-python3 detect.py /repo --out-dir /tmp/run     # write outputs here
+python3 detect.py /repo --quiet          # hide the table
+python3 detect.py /repo --no-report      # don't write report files
+python3 detect.py /repo --no-payload     # skip the shareable results payload
+python3 detect.py /repo --out-dir /tmp/run
 ```
-
----
 
 ## What it detects
 
-Three axes, each detection carrying its canonical service (`SdkServiceId` plus
-the CloudTrail-style `serviceEndpointPrefix`), its evidence (`file:line`), and
-how it was found (`detectionMethod`):
+Three axes. Each detection carries its canonical service (`SdkServiceId` and the
+CloudTrail-style `serviceEndpointPrefix`), where it came from (`file:line`), and
+how it was found (`detectionMethod`).
 
-| Axis | What | Detected from |
+| Axis | What | Where it comes from |
 |---|---|---|
-| **service** | AWS services in use (S3, DynamoDB, Lambda…) | SDK dep manifests, CDK imports, boto3/Java/Go SDK, IaC resources |
-| **cfn** | CloudFormation resource types (`AWS::Lambda::Function`) | CFN/SAM templates, CDK-synth output, CDK constructs, Terraform |
-| **api** | SDK API operations (`S3+PutObject`) | SDK call sites (TS/Py/Java/Go) + **IAM policy actions** |
+| service | Services in use (S3, DynamoDB, Lambda) | SDK manifests, CDK imports, SDK calls, IaC |
+| cfn | CloudFormation resource types (`AWS::Lambda::Function`) | CFN/SAM, CDK synth, CDK constructs, Terraform |
+| api | API operations (`S3+PutObject`) | SDK call sites (TS/Py/Java/Go) + IAM policy actions |
 
-### Detection sources
-- **CloudFormation / SAM templates** (YAML + JSON) — `AWS::Service::Resource` types, format-agnostic.
-- **CDK synthesized templates** (`cdk.out/*.template.json`) — highest fidelity; treated as ground truth.
-- **CDK construct imports** (`aws-cdk-lib/aws-<svc>`) — service + primary CFN type.
-- **Terraform** (`aws_*` resource/data blocks).
-- **SDK dependency manifests** — `package.json` (`@aws-sdk/client-*`), `requirements.txt`/`pyproject`, `pom.xml`/`build.gradle`, `go.mod`.
-- **SDK call sites** — TS v3 Command classes, boto3, Java `model.*Request`, Go SDK methods.
-- **IAM policy actions** — `"Action": ["dynamodb:Query", "s3:GetObject"]` → API operations (a precise statement of intended usage).
+### Sources it reads
 
-### Config / runtime property depth
+- CloudFormation / SAM templates (YAML and JSON). Format-agnostic.
+- CDK synth output (`cdk.out/*.template.json`, including `cdk.out.*` variants and under `build/`). Highest fidelity, everything is resolved to literals.
+- CDK construct source. L1 (`new ec2.CfnInstance(...)`) resolves to the exact CFN type; L2 imports (`aws-cdk-lib/aws-<svc>`) give the service and its primary type. It pulls config out of both, so you don't have to synth first.
+- Terraform (`aws_*` resource and data blocks).
+- SDK dependency manifests: `package.json`, `requirements.txt`/`pyproject`, `pom.xml`/`build.gradle`, `go.mod`.
+- SDK call sites: TS v3 Command classes, boto3, Java `model.*Request`, Go SDK methods.
+- IAM policy actions: `"Action": ["dynamodb:Query", "s3:GetObject"]` becomes API operations. That's a statement of intent, not proof the call runs.
 
-Beyond *which* resources exist, it extracts *how they're configured* — shown in
-the report's **Config** column and the JSON `attributes` field:
+### Config it pulls out
 
-| Resource | Properties extracted |
+It doesn't just tell you a resource exists, it tells you how it's configured.
+Shows up in the report's Config column and the JSON `attributes` field.
+
+| Resource | Properties |
 |---|---|
 | Lambda | runtime, memory, timeout, architecture |
 | EC2 instance | instanceType, ami |
@@ -94,68 +90,65 @@ the report's **Config** column and the JSON `attributes` field:
 | EKS / OpenSearch | version / engineVersion |
 | DynamoDB / ECS / Glue | billingMode / cpu, memory / glueVersion, workerType |
 
-**How a value is resolved (deterministic):**
-1. **Literal** (`instance_type = "m5.large"`, `Runtime: java17`) → extracted directly.
-2. **Same-scope default** — a Terraform `variable`/`locals` default or a CFN `Parameters` `Default:` → resolved.
-3. **Repo-wide constant** — a value in a `*.tfvars` file → resolved (all observed values reported).
-4. **Anything else** — expression, cross-module value, deploy-time input, or a wrapper construct whose value lives in another file → reported as `<unresolved>`. The detector **never** invents a value the repo doesn't contain.
+Works from CloudFormation/SAM, Terraform, and CDK source (L1 and L2 constructs).
 
-> **Higher fidelity:** run your IaC's own resolver first and scan its output.
-> - **CDK:** `cdk synth` → scan `cdk.out/*.template.json` (fully-resolved literals, including through wrapper constructs).
-> - **Terraform:** `terraform plan -out=plan.tfplan && terraform show -json plan.tfplan > plan.json` → scan the resolved plan.
+How it figures out a value, in order:
 
-### Grounding (accuracy)
+1. Literal (`instance_type = "m5.large"`, `Runtime: java17`, `runtime: 'nodejs20.x'`). Taken as-is.
+2. Reference to a same-scope default (a Terraform `variable`/`locals` default, or a CFN `Parameters` `Default:`). Resolved.
+3. Reference to a repo-wide constant in a `*.tfvars` file. Resolved, and if the repo declares more than one value it reports all of them.
+4. A CDK enum or builder expression (`ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO)`, `Runtime.JAVA_17`). Kept verbatim so the tokens survive (`T3` + `MICRO`), and something downstream turns that into `t3.micro`. The tool deliberately doesn't map enums to strings itself, so it never goes stale when AWS ships new types.
+5. Anything else (a cross-file variable, a deploy-time input). Reported as `<unresolved>`. It never makes up a value the repo doesn't contain.
 
-Every service and API operation is validated against the bundled
-`aws-api-universe.json.gz` (the authoritative set of AWS services/operations,
-generated from `botocore`). This canonicalizes names (`events` → `EventBridge`)
-and drops false positives (e.g. a pandas `.read_csv()` misread as `S3+ReadCsv`,
-or an IAM wildcard `s3:*`). If the data file is absent, detection still runs but
-grounding is skipped — keep it next to `detect.py`.
+Want the cleanest values? Run your IaC's own resolver first and point the tool at
+the output. It reads that automatically and unions it with what it found in
+source, so you get both the resolved literal and the source form.
 
-Detection is **deterministic**: identical inputs → byte-identical output.
+- CDK: `cdk synth`, then scan as usual (it finds `cdk.out/`, including `build/cdk.out`). Every property comes out resolved (`t3.micro` instead of the enum). A repo can have more than one CDK app, so synth each one to catch all the stacks.
+- Terraform: `terraform plan -out=plan.tfplan && terraform show -json plan.tfplan > plan.json`, then scan the plan JSON.
 
----
+### Grounding
+
+Every service and API operation is checked against the bundled
+`aws-api-universe.json.gz` (the real set of AWS services and operations,
+generated from `botocore`). That canonicalizes names (`events` becomes
+`EventBridge`) and drops false positives, like a pandas `.read_csv()` misread as
+`S3+ReadCsv` or an IAM wildcard `s3:*`. If the data file isn't there, detection
+still runs but skips grounding, so keep it next to `detect.py`.
+
+Detection is deterministic: same input, byte-identical output.
 
 ## Output
 
-Written into the current directory by default (override with `--out-dir DIR`):
+Goes to the current directory unless you pass `--out-dir`:
 
 ```
 capabilities-report-<runid>.html    # styled, self-contained, open in a browser
-capabilities-report-<runid>.md      # shareable Markdown
+capabilities-report-<runid>.md      # markdown
 capabilities-report-<runid>.json    # machine-readable detections
-capabilities-payload-<runid>.json   # structured results to share with AWS
+capabilities-payload-<runid>.json   # structured results to share
 ```
 
-`<runid>` is a UTC timestamp + short random suffix, so every run is distinct.
+`<runid>` is a UTC timestamp plus a short random suffix, so runs don't collide.
 
-### Sharing results with AWS
+### Sharing results
 
-The tool is fully offline — it does **not** upload anything. After a scan it
-writes `capabilities-payload-<runid>.json` (the detected capability inventory,
-tagged with the customer/application you provide) and prints a short notice
-asking you to send that one file to your AWS point of contact for ingestion.
-
-The payload contains **only** the detected AWS capability inventory — **no
-source code, no file contents.** Use `--no-payload` to skip writing it.
-
----
+The tool doesn't upload anything. After a scan it writes
+`capabilities-payload-<runid>.json` (the detected inventory, tagged with the
+customer/application you gave it) and prints a note telling you to send that one
+file to your AWS contact. Review it before you send it. It contains only the
+detected capability inventory, no source code and no file contents. Skip it with
+`--no-payload`.
 
 ## Files
 
 | File | Purpose |
 |---|---|
 | `detect.py` | The whole tool. |
-| `aws-api-universe.json.gz` | Bundled AWS service/operation universe for grounding. **Keep next to `detect.py`.** |
+| `aws-api-universe.json.gz` | AWS service/operation data for grounding. Keep it next to `detect.py`. |
 
----
+## Notes and limits
 
-## Notes / limitations
-
-- **Feature-level detection** (e.g. "Lambda SnapStart") is out of scope — that
-  needs semantic reasoning about configuration.
-- **CDK source** without `cdk synth` gives service-level + primary-CFN-type
-  signal; run `cdk synth` first for full CFN fidelity and property depth.
-- The detector reads code statically — it reports what the code *can* use, not a
-  runtime trace of what it *did* use (that's the CloudTrail input mode).
+- Feature-level detection (like "Lambda SnapStart") is out of scope. That needs semantic reasoning about config.
+- CDK source works without `cdk synth`: L1 constructs resolve to exact CFN types and config gets pulled out, with enum/builder expressions kept verbatim. Synth is optional and just gives you cleaner resolved values (`t3.micro` instead of the enum). When both source and synth are present, the tool unions them.
+- It reads code statically, so it reports what the code can use, not a trace of what actually ran. For that, feed it CloudTrail logs.

--- a/scripts/static-detector/detect.py
+++ b/scripts/static-detector/detect.py
@@ -327,8 +327,12 @@ _CFN_PROPERTY_CATALOG = {
     "AWS::Glue::Job": {"GlueVersion": "glueVersion", "WorkerType": "workerType"},
 }
 
-# key: value  — captures the property name and the rest of the line as value.
-_CFN_KV_RE = re.compile(r'^(\s*)([A-Za-z0-9]+)\s*:\s*(.+?)\s*$')
+# key: value — captures the property name and the rest of the line as value.
+# Handles BOTH YAML (`Runtime: java17`) and JSON (`"Runtime": "java17",`) so the
+# same indent-based block-walk works on `cdk synth` JSON templates, not just
+# YAML. The key may be quoted; a trailing comma on the JSON value is stripped by
+# _clean_value.
+_CFN_KV_RE = re.compile(r'^(\s*)"?([A-Za-z0-9]+)"?\s*:\s*(.+?)\s*$')
 # A value we cannot resolve to a literal. Two families:
 #   CFN: intrinsics / refs / templating   (!Ref, !GetAtt, ${...}, Fn::, {, [)
 #   Terraform: variable & expression refs  (var.x, local.x, data.x, module.x,
@@ -697,6 +701,155 @@ def extract_tf_properties(text, rel_path):
         if cfn:
             out.append((cfn, rel_path, blk["props"]))
     return out
+
+
+# --------------------------------------------------------------------------- #
+# CDK L2 construct property extraction (source, no synth required).
+#
+# L2 constructs (`new lambda.Function(this, 'id', { runtime: ..., memorySize: })`)
+# carry config as constructor props. Many are plain literals ('nodejs20.x', 512)
+# which we extract directly. Some are enum/builder expressions
+# (ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+# Runtime.NODEJS_20_X) which are NOT literals — for those we record the RAW
+# expression verbatim rather than dropping it, so the exact tokens (T3, MICRO,
+# NODEJS_20_X) survive for a downstream consumer to canonicalize. The detector
+# stays dumb and current-proof: it never maps enum -> string itself (that table
+# would go stale as AWS ships new types), it just reports what the code says.
+#
+# NOTE: `cdk synth` output supersedes this — a synthesized template resolves the
+# same props to literals, which extract_cfn_properties handles. This L2 pass is
+# the best-effort fallback when only raw source is available.
+# --------------------------------------------------------------------------- #
+# CDK construct class name -> (CFN type, {constructPropName: emitted attr name}).
+# Keyed by BOTH the L2 name (Function, Instance, DatabaseInstance) and the L1
+# CFN-leaf name (Function, Instance, DBInstance) since a caller may use either
+# `new lambda.Function(...)` or `new lambda.CfnFunction(...)`. The prop map
+# UNIONS the L2 and L1 property names (they often differ, e.g. L2 `instanceType`
+# vs L1 `dbInstanceClass` for RDS) so whichever the code uses, it binds.
+_CDK_L2_CONSTRUCT_CATALOG = {
+    # Lambda — L1 leaf "Function" == L2 "Function".
+    "Function":     ("AWS::Lambda::Function",
+                     {"runtime": "runtime", "memorySize": "memory",
+                      "timeout": "timeout", "architecture": "architecture"}),
+    # EC2 — L1 leaf "Instance" == L2 "Instance".
+    "Instance":     ("AWS::EC2::Instance",
+                     {"instanceType": "instanceType",
+                      "machineImage": "ami", "imageId": "ami"}),
+    # RDS instance — L2 "DatabaseInstance", L1 leaf "DBInstance".
+    "DatabaseInstance": ("AWS::RDS::DBInstance",
+                     {"engine": "engine", "engineVersion": "engineVersion",
+                      "instanceType": "instanceClass",
+                      "dbInstanceClass": "instanceClass",
+                      "allocatedStorage": "allocatedStorage"}),
+    "DBInstance":   ("AWS::RDS::DBInstance",
+                     {"engine": "engine", "engineVersion": "engineVersion",
+                      "instanceType": "instanceClass",
+                      "dbInstanceClass": "instanceClass",
+                      "allocatedStorage": "allocatedStorage"}),
+    # RDS cluster — L2 "DatabaseCluster", L1 leaf "DBCluster".
+    "DatabaseCluster": ("AWS::RDS::DBCluster",
+                     {"engine": "engine", "engineVersion": "engineVersion"}),
+    "DBCluster":    ("AWS::RDS::DBCluster",
+                     {"engine": "engine", "engineVersion": "engineVersion"}),
+    # ElastiCache — L1 leaf "CacheCluster" == L2 "CacheCluster".
+    "CacheCluster": ("AWS::ElastiCache::CacheCluster",
+                     {"engine": "engine", "engineVersion": "engineVersion",
+                      "cacheNodeType": "nodeType"}),
+    # DynamoDB — L2 "Table", L1 leaf "Table".
+    "Table":        ("AWS::DynamoDB::Table", {"billingMode": "billingMode"}),
+    # OpenSearch — L2 "Domain", L1 leaf "Domain".
+    "Domain":       ("AWS::OpenSearchService::Domain",
+                     {"version": "engineVersion", "engineVersion": "engineVersion"}),
+    # EKS — L2 "Cluster" (also generic; EKS L1 leaf is "Cluster").
+    "Cluster":      ("AWS::EKS::Cluster", {"version": "version"}),
+    # Glue job — L1 leaf "Job" == L2 "Job".
+    "Job":          ("AWS::Glue::Job",
+                     {"glueVersion": "glueVersion", "workerType": "workerType"}),
+}
+# `new <ns...>.<Construct>(` — captures the construct class name. Handles both
+# L2 (`Function`) and L1 (`CfnFunction`), and a multi-segment namespace like
+# `cdk.aws_lambda.CfnFunction`. The class is resolved against the catalog below
+# (an L1 `Cfn<Resource>` maps to the same catalog entry as its L2 sibling, since
+# CDK L1 props use the same camelCase names as L2).
+_CDK_L2_NEW_RE = re.compile(
+    r"\bnew\s+(?:[A-Za-z_][A-Za-z0-9_.]*\.)?(Cfn[A-Z][A-Za-z0-9]*|[A-Z][A-Za-z0-9]*)\s*\(")
+# A `propName: value,` inside a construct props object.
+_CDK_L2_PROP_RE = re.compile(r"^\s*([a-zA-Z][a-zA-Z0-9]*)\s*:\s*(.+?)\s*,?\s*$")
+
+
+def _cdk_value(raw):
+    """Value handling for a CDK L2 prop. A quoted string or bare number resolves
+    to that literal; anything else (an enum/builder expression like
+    InstanceType.of(...) or Runtime.NODEJS_20_X) is kept VERBATIM so the exact
+    tokens survive for a downstream consumer to canonicalize. Never guesses."""
+    v = raw.strip()
+    # Strip a trailing line comment that rode along (`// ...`), outside quotes.
+    # If the value starts with a quote, cut at its closing quote first.
+    if v[:1] in "'\"":
+        q = v[0]
+        end = v.find(q, 1)
+        if end != -1:
+            v = v[:end + 1]
+    else:
+        idx = v.find("//")
+        if idx != -1:
+            v = v[:idx]
+    v = v.strip().rstrip(",").strip()
+    if not v:
+        return None
+    # String literal.
+    if len(v) >= 2 and v[0] in "'\"" and v[-1] in "'\"":
+        return v[1:-1]
+    # Bare number (memorySize: 512).
+    if re.fullmatch(r"[0-9]+", v):
+        return v
+    # An expression / enum / reference — keep the raw text, trimmed of a
+    # trailing `.toString()` which is noise.
+    v = re.sub(r"\.toString\(\)\s*$", "", v)
+    return v
+
+
+def extract_cdk_l2_properties(text, rel_path):
+    """Extract config props from CDK L2 constructor calls. Returns
+    (cfn_type, rel_path, {attr: value}) per catalog construct instantiation.
+    Brace-depth tracks the props object; only DIRECT props (depth 1 inside the
+    constructor) bind, so nested option objects don't leak same-named keys."""
+    results = []
+    cur = None      # {"cfn": ..., "wanted": {...}, "props": {...}, "depth": int}
+    for line in text.splitlines():
+        if cur is None:
+            m = _CDK_L2_NEW_RE.search(line)
+            if m:
+                cls = m.group(1)
+                # L1 `CfnFunction` shares its config catalog with L2 `Function`.
+                lookup = cls[3:] if cls.startswith("Cfn") else cls
+                info = _CDK_L2_CONSTRUCT_CATALOG.get(lookup)
+                if info:
+                    cfn, wanted = info
+                    # Depth from this line onward (the `(` and any `{` on it).
+                    depth = line.count("{") - line.count("}")
+                    cur = {"cfn": cfn, "wanted": wanted, "props": {},
+                           "depth": depth}
+            continue
+        # Inside a construct call. Bind direct props (depth exactly 1 = inside
+        # the single props object). Check before updating depth for this line.
+        if cur["depth"] == 1:
+            pm = _CDK_L2_PROP_RE.match(line)
+            if pm:
+                key = pm.group(1)
+                if key in cur["wanted"] and cur["wanted"][key] not in cur["props"]:
+                    val = _cdk_value(pm.group(2))
+                    if val:
+                        cur["props"][cur["wanted"][key]] = val
+        cur["depth"] += line.count("{") - line.count("}")
+        # A closing paren at base depth ends the constructor call.
+        if cur["depth"] <= 0 or (cur["depth"] == 0):
+            if cur["props"]:
+                results.append((cur["cfn"], rel_path, cur["props"]))
+            cur = None
+    if cur and cur["props"]:
+        results.append((cur["cfn"], rel_path, cur["props"]))
+    return results
 
 
 def _tf_service_display(seg):
@@ -1093,6 +1246,30 @@ _CDK_IMPORT_RE = re.compile(
 # Matches the `aws_<service>` submodule token wherever it appears.
 _CDK_BARREL_RE = re.compile(r"\baws_([a-z0-9]+)\b")
 
+# L1 construct instantiation: `new <ns>.Cfn<Resource>(` (TS/JS) or
+# `<ns>.Cfn<Resource>(` (Python). L1 (Cfn*) constructs map 1:1 and unambiguously
+# to `AWS::<Service>::<Resource>` — that IS the CloudFormation naming contract —
+# so unlike an L2 import (which only implies the service's PRIMARY type), a
+# CfnInstance/CfnTable/CfnBucket pins the EXACT resource type at HIGH confidence.
+# `<ns>` is the imported alias (e.g. `ec2` from `aws_ec2 as ec2`); we resolve it
+# back to a service segment via the alias map built from the same imports.
+_CDK_L1_RE = re.compile(r"\bnew\s+([A-Za-z_][A-Za-z0-9_]*)\.Cfn([A-Za-z0-9]+)\s*\(")
+# Alias -> service segment, e.g. `import { aws_ec2 as ec2 }` gives ec2 -> ec2,
+# `import * as ec2 from 'aws-cdk-lib/aws-ec2'` gives ec2 -> ec2.
+_CDK_ALIAS_RE = re.compile(
+    r"(?:aws_([a-z0-9]+)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)"      # aws_ec2 as ec2
+    r"|\*\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\s+from\s+['\"]aws-cdk-lib/aws-([a-z0-9]+)"  # * as ec2 from '.../aws-ec2'
+    r"|\{\s*([A-Za-z_][A-Za-z0-9_, ]*)\}\s*=\s*require\(['\"]aws-cdk-lib/aws-([a-z0-9]+))")
+
+# CFN service segment -> the AWS::<Service> namespace token used in resource
+# types. Most L2 import segments equal the CFN service lowercased, but a few
+# differ; reuse CDK_SERVICE's primary type to recover the exact casing.
+def _cfn_service_for_segment(seg):
+    info = CDK_SERVICE.get(seg)
+    if info:
+        return info[1].split("::")[1]   # e.g. "EC2" from "AWS::EC2::VPC"
+    return None
+
 
 def parse_cdk_imports(text, rel_path):
     """Detect AWS services + primary CFN types from CDK construct-library imports.
@@ -1109,7 +1286,40 @@ def parse_cdk_imports(text, rel_path):
     # Barrel form is only trusted when the file actually uses aws-cdk-lib /
     # aws_cdk, so a stray `aws_foo` variable elsewhere isn't misread as CDK.
     barrel_ok = ("aws-cdk-lib" in text or "aws_cdk" in text)
+    # Build an alias -> service-segment map so a `new ec2.CfnInstance(...)` can
+    # be tied back to the ec2 service. Covers `aws_ec2 as ec2`, `* as ec2 from
+    # '.../aws-ec2'`, and `{ aws_ec2 } = require('.../aws-ec2')`. Also map the
+    # bare submodule name to itself (namespaced use like `aws_ec2.CfnInstance`).
+    alias_to_seg = {}
+    for m in _CDK_ALIAS_RE.finditer(text):
+        seg1, alias1, alias2, seg2, _names, seg3 = m.groups()
+        if seg1 and alias1:
+            alias_to_seg[alias1] = seg1
+        if alias2 and seg2:
+            alias_to_seg[alias2] = seg2
+        if seg3:
+            alias_to_seg[seg3] = seg3
+    for m in _CDK_BARREL_RE.finditer(text):
+        alias_to_seg.setdefault(m.group(1), m.group(1))          # aws_ec2 -> ec2
+
     for line_num, line in enumerate(text.splitlines(), 1):
+        # L1 construct: `new <ns>.Cfn<Resource>(` pins the EXACT AWS::Svc::Res.
+        for m in _CDK_L1_RE.finditer(line):
+            ns, resource = m.group(1), m.group(2)
+            seg = alias_to_seg.get(ns)
+            svc = _cfn_service_for_segment(seg) if seg else None
+            # Fallback: if the alias literally IS a known segment (e.g. `ec2`),
+            # use it directly even without an explicit import alias line.
+            if not svc:
+                svc = _cfn_service_for_segment(ns)
+            if svc:
+                fqn = f"AWS::{svc}::{resource}"
+                detections.append(Detection(
+                    "cfn", fqn, svc, rel_path, line_num, "cdk-construct", "high"))
+                detections.append(Detection(
+                    "service", sdk_service_display(svc.lower()), svc,
+                    rel_path, line_num, "cdk-construct", "high"))
+
         is_cdk_line = "cdk" in line or "motecdk" in line
         if not is_cdk_line and not barrel_ok:
             continue
@@ -1467,10 +1677,38 @@ def collect_files(root):
            "manifests": [], "sources": [], "tfvars": []}
     for dirpath, dirnames, filenames in os.walk(root):
         base = os.path.basename(dirpath)
-        # Prune skip dirs, but keep cdk.out.
-        dirnames[:] = [d for d in dirnames
-                       if d not in SKIP_DIRS and not (d.startswith(".") and d not in (".",))]
-        in_synth = SYNTH_DIR in dirpath.split(os.sep)
+        # Prune skip dirs and hidden dirs, with two exceptions kept:
+        #   * cdk.out (and variants like cdk.out.dev) — synth output, our
+        #     highest-fidelity source.
+        #   * a normally-skipped dir (e.g. build/, dist/) that CONTAINS a cdk.out*
+        #     subdir — CDK's default output is build/cdk.out, so pruning build/
+        #     outright would silently drop all synth templates. Keep such dirs so
+        #     the walk can descend to the cdk.out inside; their non-synth files
+        #     are still ignored because only *.template.* under a synth path are
+        #     collected.
+        def _leads_to_synth(parent, d):
+            p = os.path.join(parent, d)
+            if d == SYNTH_DIR or d.startswith(SYNTH_DIR + "."):
+                return True
+            try:
+                for sub in os.listdir(p):
+                    if sub == SYNTH_DIR or sub.startswith(SYNTH_DIR + "."):
+                        return True
+            except OSError:
+                pass
+            return False
+        dirnames[:] = [
+            d for d in dirnames
+            if (d not in SKIP_DIRS
+                and not (d.startswith(".") and d not in (".",)))
+            or _leads_to_synth(dirpath, d)]
+        # A path is "synth output" if ANY segment is cdk.out or a variant like
+        # cdk.out.dev / cdk.out.sampleenv (a repo with multiple CDK apps synths
+        # each to its own suffixed dir). Exact-match-only silently missed these
+        # and fell back to source-only, under-reporting resolved config.
+        segs = dirpath.split(os.sep)
+        in_synth = any(s == SYNTH_DIR or s.startswith(SYNTH_DIR + ".")
+                       for s in segs)
         for fn in filenames:
             full = os.path.join(dirpath, fn)
             if os.path.abspath(full) in _SELF_FILES:
@@ -1602,6 +1840,22 @@ def detect(root, cloudtrail_path=None):
         bucket = cfn_props.setdefault(cfn_type, {})
         for attr, raw in props.items():
             bucket.setdefault(attr, set()).update(resolve_value(raw, symbols))
+
+    # CDK L2 source props: values are already final (literal or verbatim enum
+    # expression), so they merge straight in without going through resolve_value
+    # (which would treat an enum expression as unresolved). Scanned here so the
+    # synth path — extract_cfn_properties above — takes precedence when present.
+    def _absorb_cdk_l2(entries):
+        for cfn_type, _rp, props in entries:
+            bucket = cfn_props.setdefault(cfn_type, {})
+            for attr, val in props.items():
+                bucket.setdefault(attr, set()).add(val)
+    for full in files["sources"]:
+        ext = os.path.splitext(full)[1].lower()
+        if ext in (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"):
+            text = _read(full)
+            if text and ("cdk" in text or "aws-cdk-lib" in text):
+                _absorb_cdk_l2(extract_cdk_l2_properties(text, rel(full)))
 
     for full in files["manifests"]:
         text = _read(full)

--- a/scripts/static-detector/detect.py
+++ b/scripts/static-detector/detect.py
@@ -809,47 +809,184 @@ def _cdk_value(raw):
     return v
 
 
-def extract_cdk_l2_properties(text, rel_path):
-    """Extract config props from CDK L2 constructor calls. Returns
-    (cfn_type, rel_path, {attr: value}) per catalog construct instantiation.
-    Brace-depth tracks the props object; only DIRECT props (depth 1 inside the
-    constructor) bind, so nested option objects don't leak same-named keys."""
-    results = []
-    cur = None      # {"cfn": ..., "wanted": {...}, "props": {...}, "depth": int}
-    for line in text.splitlines():
-        if cur is None:
-            m = _CDK_L2_NEW_RE.search(line)
-            if m:
-                cls = m.group(1)
-                # L1 `CfnFunction` shares its config catalog with L2 `Function`.
-                lookup = cls[3:] if cls.startswith("Cfn") else cls
-                info = _CDK_L2_CONSTRUCT_CATALOG.get(lookup)
-                if info:
-                    cfn, wanted = info
-                    # Depth from this line onward (the `(` and any `{` on it).
-                    depth = line.count("{") - line.count("}")
-                    cur = {"cfn": cfn, "wanted": wanted, "props": {},
-                           "depth": depth}
+def _match_balanced(text, open_pos, open_ch, close_ch):
+    """Given `text` and the index of an opening bracket at open_pos, return the
+    index of its matching close bracket, or -1. Skips brackets inside single/
+    double/backtick string literals so `'a{b'` doesn't throw off the count."""
+    depth = 0
+    i = open_pos
+    n = len(text)
+    quote = None
+    while i < n:
+        c = text[i]
+        if quote:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == open_ch:
+            depth += 1
+        elif c == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def _split_top_level_object(obj_text):
+    """Yield (key, value_text) for each TOP-LEVEL `key: value` pair in a JS/TS
+    object literal body (the text BETWEEN the outer braces). Nested objects,
+    arrays, and function-call parens are skipped over so a nested `runtime:` in
+    an inner options object never leaks. Strings are respected."""
+    n = len(obj_text)
+    i = 0
+    while i < n:
+        # Skip whitespace/commas between entries.
+        while i < n and obj_text[i] in " \t\r\n,":
+            i += 1
+        if i >= n:
+            break
+        # A key is an identifier (optionally quoted) up to the next ':'.
+        m = re.match(r'["\']?([A-Za-z_$][A-Za-z0-9_$]*)["\']?\s*:', obj_text[i:])
+        if not m:
+            # Not a key here (could be a spread, comment, etc.) — advance to the
+            # next top-level comma or nested-structure end to stay in sync.
+            i = _skip_to_next_top_level_comma(obj_text, i)
             continue
-        # Inside a construct call. Bind direct props (depth exactly 1 = inside
-        # the single props object). Check before updating depth for this line.
-        if cur["depth"] == 1:
-            pm = _CDK_L2_PROP_RE.match(line)
-            if pm:
-                key = pm.group(1)
-                if key in cur["wanted"] and cur["wanted"][key] not in cur["props"]:
-                    val = _cdk_value(pm.group(2))
-                    if val:
-                        cur["props"][cur["wanted"][key]] = val
-        cur["depth"] += line.count("{") - line.count("}")
-        # A closing paren at base depth ends the constructor call.
-        if cur["depth"] <= 0 or (cur["depth"] == 0):
-            if cur["props"]:
-                results.append((cur["cfn"], rel_path, cur["props"]))
-            cur = None
-    if cur and cur["props"]:
-        results.append((cur["cfn"], rel_path, cur["props"]))
+        key = m.group(1)
+        i += m.end()
+        # The value runs until the next top-level comma, skipping nested
+        # (), [], {} and strings.
+        start = i
+        depth = 0
+        quote = None
+        while i < n:
+            c = obj_text[i]
+            if quote:
+                if c == "\\":
+                    i += 2
+                    continue
+                if c == quote:
+                    quote = None
+            elif c in "'\"`":
+                quote = c
+            elif c in "([{":
+                depth += 1
+            elif c in ")]}":
+                depth -= 1
+            elif c == "," and depth == 0:
+                break
+            i += 1
+        yield key, obj_text[start:i].strip()
+        i += 1  # skip the comma
+
+
+def _skip_to_next_top_level_comma(s, i):
+    n = len(s)
+    depth = 0
+    quote = None
+    while i < n:
+        c = s[i]
+        if quote:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c in "([{":
+            depth += 1
+        elif c in ")]}":
+            depth -= 1
+        elif c == "," and depth == 0:
+            return i + 1
+        i += 1
+    return n
+
+
+def extract_cdk_l2_properties(text, rel_path):
+    """Extract config props from CDK construct calls (L1 `CfnFunction` and L2
+    `Function`). Returns (cfn_type, rel_path, {attr: value}) per catalog
+    construct instantiation.
+
+    Layout-independent: it finds each `new <ns>.<Construct>(`, captures the
+    whole paren-balanced call (which may span many lines or sit on one), locates
+    the TOP-LEVEL props object literal within the call args, and reads only its
+    direct keys. Works whether the object is on the same line as `new`, on its
+    own lines, or inline anywhere in the arg list, and nested option objects
+    don't leak same-named keys."""
+    results = []
+    for m in _CDK_L2_NEW_RE.finditer(text):
+        cls = m.group(1)
+        lookup = cls[3:] if cls.startswith("Cfn") else cls   # CfnFunction->Function
+        info = _CDK_L2_CONSTRUCT_CATALOG.get(lookup)
+        if not info:
+            continue
+        cfn, wanted = info
+        # The '(' is the last char the regex matched.
+        open_paren = m.end() - 1
+        close_paren = _match_balanced(text, open_paren, "(", ")")
+        if close_paren == -1:
+            continue
+        call_args = text[open_paren + 1:close_paren]
+        # Find the props object: the LAST top-level `{...}` in the arg list
+        # (CDK props are the final constructor argument).
+        obj_body = _last_top_level_object(call_args)
+        if obj_body is None:
+            continue
+        props = {}
+        for key, val_text in _split_top_level_object(obj_body):
+            if key in wanted and wanted[key] not in props:
+                val = _cdk_value(val_text)
+                if val:
+                    props[wanted[key]] = val
+        if props:
+            results.append((cfn, rel_path, props))
     return results
+
+
+def _last_top_level_object(args_text):
+    """Return the body (between braces) of the LAST top-level `{...}` in a
+    constructor's argument text, or None. CDK's props object is the final arg."""
+    last = None
+    i = 0
+    n = len(args_text)
+    quote = None
+    while i < n:
+        c = args_text[i]
+        if quote:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in "'\"`":
+            quote = c
+            i += 1
+            continue
+        if c == "{":
+            close = _match_balanced(args_text, i, "{", "}")
+            if close == -1:
+                break
+            last = args_text[i + 1:close]
+            i = close + 1
+            continue
+        if c in "([":
+            close_ch = ")" if c == "(" else "]"
+            close = _match_balanced(args_text, i, c, close_ch)
+            if close == -1:
+                break
+            i = close + 1
+            continue
+        i += 1
+    return last
 
 
 def _tf_service_display(seg):

--- a/scripts/static-detector/detect.py
+++ b/scripts/static-detector/detect.py
@@ -358,26 +358,30 @@ def _indent_of(line):
     return len(line) - len(line.lstrip(" "))
 
 
+def _strip_inline_comment(v):
+    """Strip a trailing line comment that rode along from the source (YAML `#`,
+    HCL `#`/`//`). Only when OUTSIDE quotes — a `#` inside a quoted string is
+    part of the value. Cheap heuristic: if the value starts with a quote, cut
+    at the closing quote; otherwise cut at the first ` #` / ` //`."""
+    if v[:1] in ('"', "'"):
+        q = v[0]
+        end = v.find(q, 1)
+        if end != -1:
+            return v[:end + 1]
+        return v
+    for marker in (" #", "\t#", " //", "\t//"):
+        idx = v.find(marker)
+        if idx != -1:
+            v = v[:idx].rstrip()
+    return v
+
+
 def _clean_value(raw):
     """Normalize a CFN/TF scalar value: strip quotes/commas; flag unresolved
     (intrinsic/ref/variable/expression) values rather than guessing. A value
     only survives as a literal if it starts like a literal AND has no embedded
     interpolation or ternary. Returns a string."""
-    v = raw.strip().rstrip(",")
-    # Strip a trailing line comment that rode along from the source (YAML `#`,
-    # HCL `#`/`//`). Only when OUTSIDE quotes — a `#` inside a quoted string is
-    # part of the value. Cheap heuristic: if the value starts with a quote, cut
-    # at the closing quote; otherwise cut at the first ` #` / ` //`.
-    if v[:1] in ('"', "'"):
-        q = v[0]
-        end = v.find(q, 1)
-        if end != -1:
-            v = v[:end + 1]
-    else:
-        for marker in (" #", "\t#", " //", "\t//"):
-            idx = v.find(marker)
-            if idx != -1:
-                v = v[:idx].rstrip()
+    v = _strip_inline_comment(raw.strip().rstrip(","))
     if not v or _UNRESOLVED_RE.match(v) or _HAS_EXPR_RE.search(v):
         return "<unresolved>"
     v = v.strip('"\'')
@@ -420,7 +424,7 @@ def resolve_value(raw, symbols):
     tfvars/constants) report ALL observed values — if the repo declares both
     m5.large and m5.xlarge, both are reported. Never guesses a value the repo
     does not contain."""
-    v = (raw or "").strip().rstrip(",")
+    v = _strip_inline_comment((raw or "").strip().rstrip(","))
     # Bare reference we might resolve against the symbol table.
     bare = v.strip('"\'')
     name = None


### PR DESCRIPTION
## Summary (required)

Extends the static detector to pull config out of CDK construct source (both L1 and L2), reads config from `cdk synth` JSON output, and fixes synth-output detection so it isn't silently missed. Net effect: scanning a raw CDK repo now surfaces resource types AND their config (Lambda runtime, EC2 instance type, RDS/engine versions, etc.), and running `cdk synth` first gives the cleaner resolved values.

## Details (required)

Follow-up to the initial `scripts/static-detector/` drop. Feedback on the first PR flagged that a raw CDK repo didn't surface an EC2 instance or its instance type. Digging in, there were real gaps:

1. **CDK L1 constructs weren't detected as exact resource types.** `new ec2.CfnInstance(...)` was only mapped to a service's primary type, so it read as `AWS::EC2::VPC`, never `AWS::EC2::Instance`. Now `new <ns>.Cfn<Resource>(...)` maps 1:1 to the exact `AWS::Service::Resource`. On the Capabilities repo this went from 9 to 27 resource types.

2. **Config wasn't extracted from CDK source at all.** Properties in construct calls (`runtime: 'nodejs20.x'`, `memorySize: 512`, `instanceType: ...`) were ignored. Now both L1 (`CfnFunction`) and L2 (`Function`) construct props are extracted. Literal values resolve directly; CDK enum/builder expressions (`ec2.InstanceType.of(InstanceClass.T3, InstanceSize.MICRO)`, `Runtime.JAVA_17`) are kept verbatim so the tokens survive for a consumer to canonicalize. The detector deliberately does not map enum to string itself, so it can't go stale as AWS ships new types.

3. **JSON (cdk synth) property extraction was broken.** The property reader only matched YAML `key: value`, so synthesized templates (which are JSON) yielded no config. Broadened to handle quoted JSON keys.

4. **Synth output was silently skipped in common layouts.** Detection only matched a dir named exactly `cdk.out`, and `SKIP_DIRS` pruned `build/` before reaching it, so `build/cdk.out` (CDK's default output) and variants like `cdk.out.dev` were missed entirely and it fell back to source-only. Now it matches `cdk.out` and `cdk.out.*`, and descends into otherwise-skipped dirs that contain synth output.

5. **Completed the CDK config catalog** (RDS/ElastiCache `engineVersion`, Glue `workerType` were missing; L1 vs L2 class/prop name differences reconciled).

When both source and synth are present, results are unioned per resource, so you get the resolved literal (`t3.micro`) alongside the source form.

Verified across five real repos (Capabilities plus four internal CDK apps) and against real `cdk synth` output.

## Testing (required)

Check all that apply:

- [ ] Unit tests
- [x] Local development server
- [ ] Full deployment

**How did you test this?**

Ran the detector against the Capabilities repo both ways: raw source and real `cdk synth` output (`npm run build` produces `build/cdk.out`, plus the dev app's `cdk.out.dev`). Confirmed raw source now surfaces `AWS::EC2::Instance` with `instanceType` as the verbatim enum, synth output resolves it to `t3.micro`, and scanning a tree with both unions the two. Also ran against four other internal CDK repos and confirmed Lambda runtime/memory/timeout, RDS engine/version, Glue version/workerType, and DynamoDB billing all extract. Fixtures pass; output is deterministic (same input, byte-identical output). Pure Python stdlib, no network, no new dependencies.

## Screenshots
<img width="1429" height="525" alt="image" src="https://github.com/user-attachments/assets/a3a921e5-68ac-4d2f-8dc4-42162106edbe" />

<img width="1123" height="977" alt="Screenshot 2026-07-22 at 2 35 46 PM" src="https://github.com/user-attachments/assets/25d805a0-316b-40a6-9332-e6f293744542" />


Command-line tool; sample output and the resolution rules are documented in `scripts/static-detector/README.md`.

## Versioning & Releases

No version bump. This only changes the standalone tool under `scripts/static-detector/`; it doesn't touch the packaged release artifact.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
