### PR TITLE
feat(deploy): support non-admin least-privilege deployment role

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,34 @@ npm run deploy -- \
   --enable-usage-analysis
 ```
 
-| Flag                              | Description                                                                                                                                                            |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--private-vpc-id`                | VPC ID. Must have DNS resolution and DNS hostnames enabled.                                                                                                            |
-| `--backend-subnet-id`             | Subnet without an internet gateway, used for Lambda compute. Must have a route to S3 via a Gateway VPC Endpoint, and to DynamoDB if `--enable-policy-enforcer` is set. |
-| `--api-access-subnet-id`          | Subnet with an internet gateway, used for user access and the API Gateway VPC Endpoint.                                                                                |
-| `--deployment-assets-bucket-name` | S3 bucket where deployment assets (Lambda code zip) are stored.                                                                                                        |
-| `--source-access-point-arn`       | S3 access point ARN for the capability data source (provided during onboarding).                                                                                       |
-| `--source-folders`                | Comma-separated list of data sources to pull from (default: `public`). Include additional partitions if granted access.                                                |
-| `--enable-usage-analysis`         | Deploy the opt-in Usage Analysis stack to enable personalization.                                                                                                      |
-| `--cloudtrail-bucket`             | CloudTrail logs bucket used by the analyzer (only with `--enable-usage-analysis`). Auto-discovered if omitted.                                                         |
-| `--enable-policy-enforcer`        | Deploy the opt-in Policy Enforcer stack to enable regional governance policy generation.                                                                               |
-| `--enable-chat`                   | Deploy the opt-in Chat assistant stack. Requires Amazon Bedrock with Claude model access enabled in the deployment region.                                             |
-| `--bedrock-model-id`              | Bedrock model or cross-region inference profile id for chat (only with `--enable-chat`). Defaults to `us.anthropic.claude-haiku-4-5-20251001-v1:0`.                    |
+| Flag                              | Description                                                                                                                                                                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--private-vpc-id`                | VPC ID. Must have DNS resolution and DNS hostnames enabled.                                                                                                                                                                                                    |
+| `--backend-subnet-id`             | Subnet without an internet gateway, used for Lambda compute. Must have a route to S3 via a Gateway VPC Endpoint, and to DynamoDB if `--enable-policy-enforcer` is set.                                                                                         |
+| `--api-access-subnet-id`          | Subnet with an internet gateway, used for user access and the API Gateway VPC Endpoint.                                                                                                                                                                        |
+| `--deployment-assets-bucket-name` | S3 bucket where deployment assets (Lambda code zip) are stored.                                                                                                                                                                                                |
+| `--source-access-point-arn`       | S3 access point ARN for the capability data source (provided during onboarding).                                                                                                                                                                               |
+| `--source-folders`                | Comma-separated list of data sources to pull from (default: `public`). Include additional partitions if granted access.                                                                                                                                        |
+| `--enable-usage-analysis`         | Deploy the opt-in Usage Analysis stack to enable personalization.                                                                                                                                                                                              |
+| `--cloudtrail-bucket`             | CloudTrail logs bucket used by the analyzer (only with `--enable-usage-analysis`). Auto-discovered if omitted.                                                                                                                                                 |
+| `--enable-policy-enforcer`        | Deploy the opt-in Policy Enforcer stack to enable regional governance policy generation.                                                                                                                                                                       |
+| `--enable-chat`                   | Deploy the opt-in Chat assistant stack. Requires Amazon Bedrock with Claude model access enabled in the deployment region.                                                                                                                                     |
+| `--bedrock-model-id`              | Bedrock model or cross-region inference profile id for chat (only with `--enable-chat`). Defaults to `us.anthropic.claude-haiku-4-5-20251001-v1:0`.                                                                                                            |
+| `--deployer-role-name`            | IAM role name this deployment runs as. Registered as a Lake Formation Data Lake Admin by the Usage Analysis stack so its grants succeed (only relevant with `--enable-usage-analysis`). Derived from your caller identity if omitted, falling back to `Admin`. |
+
+#### Deploying without Admin access
+
+By default the deploy runs with whatever credentials you have, which are often Admin. To deploy under a **least-privilege role** instead, use the example IAM policies in [`docs/`](docs/deployment-iam-policy.md). They are split so you attach only what you enable:
+
+| File                                              | Attach when                       |
+| ------------------------------------------------- | --------------------------------- |
+| `docs/deployment-iam-policy-base.json`            | Always (required)                 |
+| `docs/deployment-iam-policy-usage-analysis.json`  | with `--enable-usage-analysis`    |
+| `docs/deployment-iam-policy-policy-enforcer.json` | with `--enable-policy-enforcer`   |
+| `docs/deployment-iam-policy-chat.json`            | with `--enable-chat`              |
+| `docs/deployment-role-trust-policy.json`          | example trust policy for the role |
+
+Create a role, attach the base policy plus the add-on(s) for the stacks you enable, then deploy while assuming that role and pass `--deployer-role-name <RoleName>`. That name is registered as a Lake Formation Data Lake Admin by the Usage Analysis stack, so its permission grants succeed under a non-admin principal. Full steps are in [docs/deployment-iam-policy.md](docs/deployment-iam-policy.md).
 
 #### Teardown
 

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -29,6 +29,11 @@ Deploy options (pass as flags or omit to be prompted):
                                          the deploy region; unavailable in GovCloud/sovereign/ADC.
   --bedrock-model-id <id>                Bedrock model or cross-region inference profile id for
                                          chat (default: us.anthropic.claude-haiku-4-5-20251001-v1:0)
+  --deployer-role-name <name>            IAM role name this deployment runs as. Registered as a
+                                         Lake Formation Data Lake Admin by the Usage Analysis stack
+                                         so its LF grants succeed. If omitted, it is derived from
+                                         your current caller identity (falling back to "Admin").
+                                         Only relevant with --enable-usage-analysis.
   -y, --yes                              Skip confirmation prompts
 
 Examples:
@@ -144,7 +149,7 @@ deploy_stack_checked() {
 }
 
 cmd_deploy() {
-  local private_vpc_id="" backend_subnet_id="" api_access_subnet_id="" deployment_assets_bucket_name="" source_access_point_arn="" source_folders="" cloudtrail_bucket="" enable_usage_analysis="" enable_policy_enforcer="" enable_chat="" bedrock_model_id="" auto_approve=""
+  local private_vpc_id="" backend_subnet_id="" api_access_subnet_id="" deployment_assets_bucket_name="" source_access_point_arn="" source_folders="" cloudtrail_bucket="" enable_usage_analysis="" enable_policy_enforcer="" enable_chat="" bedrock_model_id="" deployer_role_name="" auto_approve=""
 
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -159,6 +164,7 @@ cmd_deploy() {
       --enable-policy-enforcer)          enable_policy_enforcer="true"; shift ;;
       --enable-chat)                     enable_chat="true"; shift ;;
       --bedrock-model-id)                bedrock_model_id="$2"; shift 2 ;;
+      --deployer-role-name)              deployer_role_name="$2"; shift 2 ;;
       -y|--yes)                          auto_approve="true"; shift ;;
       *) echo "Unknown option: $1"; usage ;;
     esac
@@ -270,6 +276,33 @@ cmd_deploy() {
 
   echo "── Deploying Usage Analysis stack ──"
   if [[ "$enable_usage_analysis" == "true" ]]; then
+    # The Usage Analysis stack registers DeployerRoleName as a Lake Formation
+    # Data Lake Admin so CloudFormation (running as the deploying principal) can
+    # create the LF Permissions grants. That role name MUST match the role this
+    # deploy actually runs as — otherwise the grants fail with AccessDenied.
+    # Resolve it: explicit --deployer-role-name > role parsed from the current
+    # caller identity > "Admin" fallback. (Only this stack needs it; the base,
+    # Policy Enforcer, and Chat stacks have no deployer-principal coupling.)
+    if [[ -z "$deployer_role_name" ]]; then
+      local caller_arn
+      caller_arn=$(aws sts get-caller-identity --query Arn --output text 2>/dev/null || echo "")
+      # arn:aws:sts::<acct>:assumed-role/<RoleName>/<session> -> <RoleName>
+      if [[ "$caller_arn" == *":assumed-role/"* ]]; then
+        deployer_role_name="${caller_arn#*:assumed-role/}"
+        deployer_role_name="${deployer_role_name%%/*}"
+      fi
+      if [[ -z "$deployer_role_name" ]]; then
+        deployer_role_name="Admin"
+        echo "  ⚠ Could not derive the deploy role from your caller identity; using DeployerRoleName=Admin."
+        echo "    If deploying with a non-admin role (or a role that uses an IAM path), pass"
+        echo "    --deployer-role-name <RoleName> so Lake Formation grants succeed."
+      else
+        echo "  Registering deploy role '$deployer_role_name' as Lake Formation Data Lake Admin."
+      fi
+    else
+      echo "  Registering deploy role '$deployer_role_name' as Lake Formation Data Lake Admin."
+    fi
+
     deploy_stack_checked CapabilityInsightsUsageAnalysis \
       --template-file "$SCRIPT_DIR/dist/template/usage-analysis.template.json" \
       --parameter-overrides \
@@ -278,6 +311,7 @@ cmd_deploy() {
         DeploymentAssetsBucketName="$deployment_assets_bucket_name" \
         LambdaCodeZipPath="$lambda_key" \
         CloudTrailBucketName="${cloudtrail_bucket:-}" \
+        DeployerRoleName="$deployer_role_name" \
       --capabilities CAPABILITY_NAMED_IAM \
       --no-cli-pager
     echo "  ✓ Usage Analysis stack deployed."

--- a/deployment/dev.sh
+++ b/deployment/dev.sh
@@ -27,6 +27,8 @@ Deploy options:
   --enable-policy-enforcer         Also deploy the opt-in Policy Enforcer stack
   --enable-chat                    Also deploy the opt-in Chat assistant stack (Bedrock)
   --bedrock-model-id <id>          Bedrock model/inference-profile id for chat (only with --enable-chat)
+  --deployer-role-name <name>      IAM role name this deploy runs as (only with --enable-usage-analysis;
+                                   derived from your caller identity if omitted)
 
 Global options:
   -y, --yes                        Skip confirmation prompts
@@ -66,7 +68,7 @@ cmd_setup() {
 }
 
 cmd_deploy() {
-  local source_access_point_arn="" source_folders="" enable_usage_analysis="" cloudtrail_bucket="" enable_policy_enforcer="" enable_chat="" bedrock_model_id=""
+  local source_access_point_arn="" source_folders="" enable_usage_analysis="" cloudtrail_bucket="" enable_policy_enforcer="" enable_chat="" bedrock_model_id="" deployer_role_name=""
   while [[ $# -gt 0 ]]; do
     case $1 in
       --source-access-point-arn) source_access_point_arn="$2"; shift 2 ;;
@@ -76,6 +78,7 @@ cmd_deploy() {
       --enable-policy-enforcer) enable_policy_enforcer="true"; shift ;;
       --enable-chat) enable_chat="true"; shift ;;
       --bedrock-model-id) bedrock_model_id="$2"; shift 2 ;;
+      --deployer-role-name) deployer_role_name="$2"; shift 2 ;;
       -y|--yes) shift ;;
       *) echo "Unknown option: $1"; usage ;;
     esac
@@ -112,6 +115,9 @@ cmd_deploy() {
     usage_analysis_args+=(--enable-usage-analysis)
     if [[ -n "$cloudtrail_bucket" ]]; then
       usage_analysis_args+=(--cloudtrail-bucket "$cloudtrail_bucket")
+    fi
+    if [[ -n "$deployer_role_name" ]]; then
+      usage_analysis_args+=(--deployer-role-name "$deployer_role_name")
     fi
   fi
 

--- a/docs/deployment-iam-policy-base.json
+++ b/docs/deployment-iam-policy-base.json
@@ -1,0 +1,187 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormationBaseStack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:ExecuteChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet"
+      ],
+      "Resource": "arn:aws:cloudformation:<REGION>:<ACCOUNT_ID>:stack/CapabilityInsightsForAWS/*"
+    },
+    {
+      "Sid": "CloudFormationTemplateSummary",
+      "Effect": "Allow",
+      "Action": "cloudformation:GetTemplateSummary",
+      "Resource": "*"
+    },
+    {
+      "Sid": "IamRoleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:UpdateRole",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:TagRole",
+        "iam:UntagRole"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/CapabilityInsights*"
+    },
+    {
+      "Sid": "IamPassRoleToServices",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/CapabilityInsights*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": ["lambda.amazonaws.com", "apigateway.amazonaws.com"]
+        }
+      }
+    },
+    {
+      "Sid": "Lambda",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:CreateFunction",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:AddPermission",
+        "lambda:RemovePermission",
+        "lambda:GetPolicy",
+        "lambda:ListVersionsByFunction",
+        "lambda:TagResource",
+        "lambda:UntagResource",
+        "lambda:ListTags",
+        "lambda:InvokeFunction"
+      ],
+      "Resource": "arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function:CapabilityInsights*"
+    },
+    {
+      "Sid": "S3WebsiteAndDeploymentAssets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:PutEncryptionConfiguration",
+        "s3:GetEncryptionConfiguration",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:PutBucketWebsite",
+        "s3:GetBucketWebsite",
+        "s3:PutBucketPolicy",
+        "s3:GetBucketPolicy",
+        "s3:DeleteBucketPolicy",
+        "s3:GetBucketAcl",
+        "s3:PutBucketTagging",
+        "s3:GetBucketTagging",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::capability-insights-website-<ACCOUNT_ID>-<REGION>",
+        "arn:aws:s3:::capability-insights-website-<ACCOUNT_ID>-<REGION>/*",
+        "arn:aws:s3:::<DEPLOYMENT_ASSETS_BUCKET>",
+        "arn:aws:s3:::<DEPLOYMENT_ASSETS_BUCKET>/*"
+      ]
+    },
+    {
+      "Sid": "Ec2Networking",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:CreateVpcEndpoint",
+        "ec2:DeleteVpcEndpoints",
+        "ec2:ModifyVpcEndpoint",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSecurityGroupRules",
+        "ec2:DescribeVpcEndpoints",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribePrefixLists",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ApiGateway",
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:POST",
+        "apigateway:GET",
+        "apigateway:PUT",
+        "apigateway:PATCH",
+        "apigateway:DELETE",
+        "apigateway:UpdateRestApiPolicy"
+      ],
+      "Resource": "arn:aws:apigateway:<REGION>::/*"
+    },
+    {
+      "Sid": "EventBridgeSchedules",
+      "Effect": "Allow",
+      "Action": [
+        "events:PutRule",
+        "events:DeleteRule",
+        "events:DescribeRule",
+        "events:PutTargets",
+        "events:RemoveTargets",
+        "events:ListTargetsByRule",
+        "events:TagResource"
+      ],
+      "Resource": "arn:aws:events:<REGION>:<ACCOUNT_ID>:rule/CapabilityInsights*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:DescribeLogGroups",
+        "logs:TagLogGroup",
+        "logs:TagResource",
+        "logs:ListTagsForResource"
+      ],
+      "Resource": "arn:aws:logs:<REGION>:<ACCOUNT_ID>:log-group:*"
+    },
+    {
+      "Sid": "CallerIdentity",
+      "Effect": "Allow",
+      "Action": "sts:GetCallerIdentity",
+      "Resource": "*"
+    }
+  ]
+}

--- a/docs/deployment-iam-policy-chat.json
+++ b/docs/deployment-iam-policy-chat.json
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormationChatStack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:ExecuteChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet"
+      ],
+      "Resource": "arn:aws:cloudformation:<REGION>:<ACCOUNT_ID>:stack/CapabilityInsightsChat/*"
+    },
+    {
+      "Sid": "BedrockChatPreflight",
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": ["arn:aws:bedrock:*::foundation-model/*", "arn:aws:bedrock:<REGION>:<ACCOUNT_ID>:inference-profile/*"]
+    }
+  ]
+}

--- a/docs/deployment-iam-policy-policy-enforcer.json
+++ b/docs/deployment-iam-policy-policy-enforcer.json
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormationPolicyEnforcerStack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:ExecuteChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet"
+      ],
+      "Resource": "arn:aws:cloudformation:<REGION>:<ACCOUNT_ID>:stack/CapabilityInsightsPolicyEnforcer/*"
+    },
+    {
+      "Sid": "DynamoDbPolicyEnforcer",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:UpdateTable",
+        "dynamodb:UpdateContinuousBackups",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource",
+        "dynamodb:ListTagsOfResource"
+      ],
+      "Resource": "arn:aws:dynamodb:<REGION>:<ACCOUNT_ID>:table/CapabilityInsights*"
+    }
+  ]
+}

--- a/docs/deployment-iam-policy-usage-analysis.json
+++ b/docs/deployment-iam-policy-usage-analysis.json
@@ -1,0 +1,100 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormationUsageAnalysisStack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:ExecuteChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet"
+      ],
+      "Resource": "arn:aws:cloudformation:<REGION>:<ACCOUNT_ID>:stack/CapabilityInsightsUsageAnalysis/*"
+    },
+    {
+      "Sid": "IamPassRoleStatesAndEvents",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/CapabilityInsights*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": ["states.amazonaws.com", "events.amazonaws.com"]
+        }
+      }
+    },
+    {
+      "Sid": "StepFunctions",
+      "Effect": "Allow",
+      "Action": [
+        "states:CreateStateMachine",
+        "states:DeleteStateMachine",
+        "states:DescribeStateMachine",
+        "states:UpdateStateMachine",
+        "states:TagResource",
+        "states:UntagResource",
+        "states:ListTagsForResource",
+        "states:StartExecution"
+      ],
+      "Resource": "arn:aws:states:<REGION>:<ACCOUNT_ID>:stateMachine:CapabilityInsights*"
+    },
+    {
+      "Sid": "Glue",
+      "Effect": "Allow",
+      "Action": [
+        "glue:CreateDatabase",
+        "glue:DeleteDatabase",
+        "glue:UpdateDatabase",
+        "glue:GetDatabase",
+        "glue:GetDatabases",
+        "glue:CreateTable",
+        "glue:DeleteTable",
+        "glue:UpdateTable",
+        "glue:GetTable",
+        "glue:GetTables"
+      ],
+      "Resource": [
+        "arn:aws:glue:<REGION>:<ACCOUNT_ID>:catalog",
+        "arn:aws:glue:<REGION>:<ACCOUNT_ID>:database/cloudtrail_analysis",
+        "arn:aws:glue:<REGION>:<ACCOUNT_ID>:table/cloudtrail_analysis/*",
+        "arn:aws:glue:<REGION>:<ACCOUNT_ID>:userDefinedFunction/cloudtrail_analysis/*"
+      ]
+    },
+    {
+      "Sid": "LakeFormation",
+      "Effect": "Allow",
+      "Action": [
+        "lakeformation:GetDataLakeSettings",
+        "lakeformation:GrantPermissions",
+        "lakeformation:RevokePermissions",
+        "lakeformation:ListPermissions"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AthenaRuntimeValidation",
+      "Effect": "Allow",
+      "Action": [
+        "athena:StartQueryExecution",
+        "athena:GetQueryExecution",
+        "athena:GetQueryResults",
+        "athena:StopQueryExecution",
+        "athena:GetWorkGroup"
+      ],
+      "Resource": "arn:aws:athena:<REGION>:<ACCOUNT_ID>:workgroup/primary"
+    },
+    {
+      "Sid": "CloudTrailBucketDiscovery",
+      "Effect": "Allow",
+      "Action": "cloudtrail:DescribeTrails",
+      "Resource": "*"
+    }
+  ]
+}

--- a/docs/deployment-iam-policy.md
+++ b/docs/deployment-iam-policy.md
@@ -1,0 +1,89 @@
+# Least-privilege deployment role
+
+These files are an **example** set of least-privilege IAM policies for a role that
+can deploy Capability Insights for AWS **without Admin access**. They are a
+starting point — review and scope them to your account before using them.
+
+Because the three add-on stacks are opt-in, the policy is **split** so you attach
+only what you actually deploy:
+
+| File                                         | When to attach                  | Grants                                                                                                                                                                                                              |
+| -------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deployment-iam-policy-base.json`            | **Always** (required)           | CloudFormation (base stack) + template summary, IAM roles + PassRole (lambda/apigateway), Lambda, S3 (website + assets buckets), EC2 networking, API Gateway, EventBridge, CloudWatch Logs, `sts:GetCallerIdentity` |
+| `deployment-iam-policy-usage-analysis.json`  | with `--enable-usage-analysis`  | CloudFormation (usage stack), Step Functions (+`StartExecution`), Glue, Lake Formation grants, Athena (runtime), PassRole (states/events), `cloudtrail:DescribeTrails`                                              |
+| `deployment-iam-policy-policy-enforcer.json` | with `--enable-policy-enforcer` | CloudFormation (policy-enforcer stack), DynamoDB                                                                                                                                                                    |
+| `deployment-iam-policy-chat.json`            | with `--enable-chat`            | CloudFormation (chat stack), `bedrock:InvokeModel` (deploy-time preflight)                                                                                                                                          |
+
+The add-ons deliberately do **not** repeat the base grants: every stack's IAM
+roles, Lambdas, log groups, security groups, and EventBridge rules are named
+`CapabilityInsights*` and are already covered by the base policy, which is always
+attached (the add-on stacks require the base stack to exist first). Each file is
+well under the 6,144-char customer-managed-policy limit (base ~3,960; add-ons
+< 2,200 each), so attach them as separate managed policies (a role allows up to
+10), or concatenate the statements into one inline policy.
+
+## Using it
+
+1. Replace the placeholders in each file you attach:
+   - `<ACCOUNT_ID>` — your AWS account id
+   - `<REGION>` — the region you deploy into
+   - `<DEPLOYMENT_ASSETS_BUCKET>` — the bucket you pass as `--deployment-assets-bucket-name` (base file)
+2. Create a role your identity can assume; attach `-base` plus the add-on(s) for
+   the flags you will use. `deployment-role-trust-policy.json` in this folder is an
+   example trust policy — replace `<TRUSTED_PRINCIPAL_ARN>` with the identity that
+   will run the deploy (e.g. `arn:aws:iam::<ACCOUNT_ID>:role/<YourAdminOrSsoRole>`
+   or your CI role). Example — base + usage analysis:
+   ```bash
+   aws iam create-role --role-name CapInsightsDeployer \
+     --assume-role-policy-document file://docs/deployment-role-trust-policy.json
+   aws iam put-role-policy --role-name CapInsightsDeployer --policy-name ci-deploy-base \
+     --policy-document file://docs/deployment-iam-policy-base.json
+   aws iam put-role-policy --role-name CapInsightsDeployer --policy-name ci-deploy-usage \
+     --policy-document file://docs/deployment-iam-policy-usage-analysis.json
+   ```
+3. Deploy while assuming that role, and tell the deploy which role it is so Lake
+   Formation is configured correctly (see below):
+   ```bash
+   npm run deploy -- --deployer-role-name CapInsightsDeployer \
+     --deployment-assets-bucket-name <DEPLOYMENT_ASSETS_BUCKET> \
+     --source-access-point-arn <arn> \
+     --enable-usage-analysis
+   ```
+   If you omit `--deployer-role-name`, `deploy.sh` derives it from your caller
+   identity (falling back to `Admin`).
+
+## Why `--deployer-role-name` matters (Lake Formation)
+
+Only the **Usage Analysis** stack couples to the deploying principal. It registers
+the deploy role as a Lake Formation **Data Lake Admin** (via the `DeployerRoleName`
+template parameter) so its `AWS::LakeFormation::Permissions` grants can be created.
+That name **must match the role CloudFormation actually runs as** — otherwise the
+grants fail with `AccessDeniedException`. `deploy.sh` now passes it automatically.
+
+Caveat: if your account **already** has Lake Formation enabled with Data Lake
+Admins that exclude your deploy role, the bootstrap cannot add itself. In that
+case an existing LF admin must add the deploy role (or grant it
+`lakeformation:PutDataLakeSettings`) before the first deploy.
+
+The base, Policy Enforcer, and Chat stacks have **no** deployer-principal coupling
+and need nothing beyond the resource permissions in their files.
+
+## Notes on specific grants
+
+- `athena:*` in the usage-analysis file is scoped to the account's default
+  `primary` workgroup. It is primarily a **runtime** path used by the analyzer
+  Lambda's own role; it is included here for completeness and if you validate
+  queries as the deploy role.
+- `cloudformation:GetTemplateSummary` is in the **base** file on `Resource: "*"`
+  (it does not support resource-level scoping) — `aws cloudformation deploy` calls
+  it on every stack update, so it is required even for update-only runs.
+- `Resource: "*"` on EC2, API Gateway, and Lake Formation reflects that those
+  actions are poorly resource-scopeable. Tighten with your own conditions if your
+  guardrails require it.
+
+## Not yet validated end-to-end
+
+These policies were synthesized from a per-stack audit of the CloudFormation
+templates and cross-checked against `deploy.sh`, but have **not** yet been
+verified by a full deployment under a freshly-created non-admin role (tracked as
+the E2E item in ALM-2681). Expect to iterate and add anything a real run surfaces.

--- a/docs/deployment-role-trust-policy.json
+++ b/docs/deployment-role-trust-policy.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "<TRUSTED_PRINCIPAL_ARN>" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.5.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capability-insights-for-aws",
-      "version": "1.5.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "workspaces": [
         "source/shared",
@@ -8085,7 +8085,7 @@
     },
     "source/constructs": {
       "name": "@capability-insights/constructs",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@tsconfig/node-lts": "^20.1.3",
@@ -8185,7 +8185,7 @@
     },
     "source/shared": {
       "name": "@capability-insights/shared",
-      "version": "1.4.0"
+      "version": "1.6.0"
     },
     "source/website": {
       "name": "@capability-insights/website",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capability-insights-for-aws",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [


### PR DESCRIPTION
## What & why

Capability Insights previously assumed the deploying identity was **Admin**: `deploy.sh` never passed `DeployerRoleName` to the Usage Analysis stack, so its Lake Formation `Permissions` grants fail under any non-admin role (the deploy role isn't registered as a Data Lake Admin). This blocks the launch requirement that the solution deploy without Admin. 

## Changes

- **`deployment/deploy.sh`** — new `--deployer-role-name` flag; when omitted it derives the role from the caller identity (falling back to `Admin`), and passes it as `DeployerRoleName` to the Usage Analysis stack so the *actual* deploy role becomes the LF Data Lake Admin.
- **`deployment/dev.sh`** — passes `--deployer-role-name` through.
- **`docs/`** — example least-privilege IAM policies, **split so you attach only what you enable**:
  - `deployment-iam-policy-base.json` (always) + `-usage-analysis` / `-policy-enforcer` / `-chat` add-ons
  - `deployment-role-trust-policy.json` (example trust policy)
  - `deployment-iam-policy.md` (attach-what-you-enable guide)
- **`README.md`** — new "Deploying without Admin access" section + `--deployer-role-name` flag row.
- **Version** — `1.7.0` → `1.8.0`.

## Scope of the opt-in stacks

An audit of all four CloudFormation templates confirmed **only the Usage Analysis stack couples to the deploying principal** (LF Data Lake Admin). Base, Policy Enforcer, and Chat have no such coupling — the split policies reflect that.

## Validation

- `bash -n` on both scripts; all policy JSON validates.
- **End-to-end**: created a role from these policies (base + all three add-ons), assumed it, and deployed under it — **all four stacks reached CREATE/UPDATE_COMPLETE with zero AccessDenied**, and LF `DataLakeAdmins` correctly listed the non-admin deploy role.
